### PR TITLE
Add multicall wait time

### DIFF
--- a/packages/config/env/index.ts
+++ b/packages/config/env/index.ts
@@ -95,6 +95,10 @@ export const blockTime = Number(process.env.NEXT_PUBLIC_BLOCKTIME);
 // Precompiles & contracts
 export const multicallAddress = process.env
   .NEXT_PUBLIC_MULTICALL_ADDRESS as Address;
+export const multicallCreationBlock = process.env
+  .NEXT_PUBLIC_MULTICALL_CREATION_BLOCK
+  ? Number(process.env.NEXT_PUBLIC_MULTICALL_CREATION_BLOCK)
+  : undefined;
 export const erc20DexAddress = process.env
   .NEXT_PUBLIC_ERC20_DEX_ADDRESS as Address;
 export const erc20ModuleAddress = process.env

--- a/packages/wagmi/src/config/defaultBeraJsConfig.ts
+++ b/packages/wagmi/src/config/defaultBeraJsConfig.ts
@@ -70,6 +70,11 @@ export const wagmiConfig = createConfig({
   chains: [defaultBeraNetworkConfig.chain],
   multiInjectedProviderDiscovery: false,
   ssr: false,
+  batch: {
+    multicall: {
+      wait: 10,
+    },
+  },
   transports: {
     [defaultBeraNetworkConfig.chain.id]: http(
       defaultBeraNetworkConfig.chain.rpcUrls.default.http[0] || "",

--- a/packages/wagmi/src/config/defaultBeraJsConfig.ts
+++ b/packages/wagmi/src/config/defaultBeraJsConfig.ts
@@ -9,6 +9,8 @@ import {
   gasTokenSymbol,
   jsonRpcUrl,
   publicJsonRpcUrl,
+  multicallAddress,
+  multicallCreationBlock,
 } from "@bera/config";
 import { EvmNetwork } from "@dynamic-labs/sdk-react-core";
 import { type Chain } from "viem";
@@ -23,6 +25,13 @@ const BeraChain: Chain = {
     decimals: gasTokenDecimals,
     name: gasTokenName,
     symbol: gasTokenSymbol,
+  },
+
+  contracts: {
+    multicall3: {
+      address: multicallAddress,
+      blockCreated: multicallCreationBlock,
+    },
   },
   blockExplorers: {
     etherscan: {
@@ -71,6 +80,9 @@ export const wagmiConfig = createConfig({
   multiInjectedProviderDiscovery: false,
   ssr: false,
   batch: {
+    /**
+     * @see https://viem.sh/docs/clients/public#batchmulticallwait-optional
+     */
     multicall: {
       wait: 10,
     },


### PR DESCRIPTION
By adding this to wagmi config, it'll automatically batch call even if they're not done using multicall3. Very useful imo.

On vault page it decreseas chain network requests by 30-50%, but this affects all projects so I think it can be an improvement all over the monorepo. The only cons is that it adds a 10ms latency to requests but it's a fair tradeoff in my opinion. Let me know your thoughs about it.

```
  batch: {
    multicall: {
      wait: 10,
    },
  },
```

No need to use `multicall3` directly in this way. [Docs here](https://viem.sh/docs/clients/public#batchmulticallwait-optional)