### PR TITLE
Layout.ts files are now RSC

### DIFF
--- a/apps/bgt-station/src/app/layout.tsx
+++ b/apps/bgt-station/src/app/layout.tsx
@@ -3,7 +3,9 @@
 import "@bera/ui/styles.css";
 import "../styles/globals.css";
 import { IBM_Plex_Sans } from "next/font/google";
+import { usePathname } from "next/navigation";
 import Script from "next/script";
+import { bgtName } from "@bera/config";
 import {
   Header,
   TailwindIndicator,
@@ -13,12 +15,9 @@ import {
 import { cn } from "@bera/ui";
 import { Analytics } from "@vercel/analytics/react";
 import { Toaster } from "react-hot-toast";
-import { useLocalStorage } from "usehooks-ts";
 
 import Providers from "./Providers";
 import { navItems } from "./config";
-import { bgtName } from "@bera/config";
-import { usePathname } from "next/navigation";
 
 const fontSans = IBM_Plex_Sans({
   weight: ["400", "500", "600", "700"],
@@ -27,11 +26,6 @@ const fontSans = IBM_Plex_Sans({
 });
 
 export default function RootLayout(props: { children: React.ReactNode }) {
-  const [firstTimeUser, setFirstTimeUser] = useLocalStorage(
-    "FIRST_TIME_USER",
-    true,
-  );
-
   const pathName = usePathname();
   const activeBanners = getBannerCount(bgtName, pathName);
 
@@ -54,7 +48,7 @@ export default function RootLayout(props: { children: React.ReactNode }) {
       <body
         className={cn("min-h-screen font-sans antialiased", fontSans.variable)}
       >
-        <TermOfUseModal open={firstTimeUser} setOpen={setFirstTimeUser} />
+        <TermOfUseModal />
         <Providers>
           <div className="relative flex min-h-screen w-full flex-col overflow-hidden">
             <div className="z-[100]">

--- a/apps/dex/src/app/layout.tsx
+++ b/apps/dex/src/app/layout.tsx
@@ -54,7 +54,7 @@ export default function RootLayout(props: { children: React.ReactNode }) {
         className={cn("min-h-screen font-sans antialiased", fontSans.variable)}
       >
         <span className="warning-foreground hidden text-amber-300 text-green-300 text-green-400 text-green-500 text-neutral-400 text-red-400 text-red-500" />
-        <TermOfUseModal open={firstTimeUser} setOpen={setFirstTimeUser} />
+        <TermOfUseModal />
         <Providers>
           <div className="relative flex min-h-screen w-full flex-col overflow-hidden">
             <div className="z-[100]">

--- a/apps/dex/src/app/layout.tsx
+++ b/apps/dex/src/app/layout.tsx
@@ -1,21 +1,17 @@
-"use client";
-
 import "@bera/ui/styles.css";
 import "../styles/globals.css";
 import { IBM_Plex_Sans } from "next/font/google";
-import { usePathname } from "next/navigation";
 import Script from "next/script";
 import { dexName } from "@bera/config";
 import {
   Header,
+  MainWithBanners,
   TailwindIndicator,
   TermOfUseModal,
-  getBannerCount,
 } from "@bera/shared-ui";
 import { cn } from "@bera/ui";
 import { Analytics } from "@vercel/analytics/react";
 import { Toaster } from "react-hot-toast";
-import { useLocalStorage } from "usehooks-ts";
 
 import { navItems } from "~/app/config";
 import Providers from "./Providers";
@@ -27,13 +23,6 @@ const fontSans = IBM_Plex_Sans({
 });
 
 export default function RootLayout(props: { children: React.ReactNode }) {
-  const [firstTimeUser, setFirstTimeUser] = useLocalStorage(
-    "FIRST_TIME_USER",
-    true,
-  );
-  const pathName = usePathname();
-  const activeBanners = getBannerCount(dexName, pathName);
-
   return (
     <html lang="en" className="bg-background">
       <Script
@@ -63,12 +52,9 @@ export default function RootLayout(props: { children: React.ReactNode }) {
             <div className="z-10 flex-1">
               <span className="hidden text-amber-300 text-green-300 text-green-400 text-green-500 text-neutral-400 text-red-400 text-red-500" />
               <Header navItems={navItems} appName={dexName} />
-              <main
-                className="w-full"
-                style={{ paddingTop: `${48 * activeBanners + 72}px` }}
-              >
+              <MainWithBanners appName={dexName}>
                 {props.children}
-              </main>
+              </MainWithBanners>
             </div>
           </div>
           <TailwindIndicator />

--- a/apps/honey/src/app/layout.tsx
+++ b/apps/honey/src/app/layout.tsx
@@ -3,7 +3,6 @@
 import "@bera/ui/styles.css";
 import "../styles/globals.css";
 import { IBM_Plex_Sans, Jua } from "next/font/google";
-import { usePathname } from "next/navigation";
 import Script from "next/script";
 import { ApolloProvider } from "@apollo/client";
 import { honeyName } from "@bera/config";
@@ -11,9 +10,9 @@ import { honeyClient } from "@bera/graphql";
 import {
   Footer,
   Header,
+  MainWithBanners,
   TailwindIndicator,
   TermOfUseModal,
-  getBannerCount,
 } from "@bera/shared-ui";
 import { cn } from "@bera/ui";
 import { BeraWagmi } from "@bera/wagmi";
@@ -35,8 +34,6 @@ const fontHoney = Jua({
 });
 
 export default function RootLayout(props: { children: React.ReactNode }) {
-  const pathName = usePathname();
-  const activeBanners = getBannerCount(honeyName, pathName);
   return (
     <html lang="en" suppressHydrationWarning>
       <Script
@@ -70,12 +67,9 @@ export default function RootLayout(props: { children: React.ReactNode }) {
               mobileNavItems={mobileNavItems}
               appName={honeyName}
             />
-            <main
-              className="w-full pt-start"
-              style={{ paddingTop: `${48 * activeBanners + 72}px` }}
-            >
+            <MainWithBanners className="pt-start" appName={honeyName}>
               {props.children}
-            </main>
+            </MainWithBanners>
             <Toaster position="bottom-right" />
             <Footer />
             <TailwindIndicator />

--- a/apps/honey/src/app/layout.tsx
+++ b/apps/honey/src/app/layout.tsx
@@ -3,8 +3,8 @@
 import "@bera/ui/styles.css";
 import "../styles/globals.css";
 import { IBM_Plex_Sans, Jua } from "next/font/google";
-import Script from "next/script";
 import { usePathname } from "next/navigation";
+import Script from "next/script";
 import { ApolloProvider } from "@apollo/client";
 import { honeyName } from "@bera/config";
 import { honeyClient } from "@bera/graphql";
@@ -19,7 +19,6 @@ import { cn } from "@bera/ui";
 import { BeraWagmi } from "@bera/wagmi";
 import { Analytics } from "@vercel/analytics/react";
 import { Toaster } from "react-hot-toast";
-import { useLocalStorage } from "usehooks-ts";
 
 import { mobileNavItems, navItems } from "./config";
 
@@ -36,10 +35,6 @@ const fontHoney = Jua({
 });
 
 export default function RootLayout(props: { children: React.ReactNode }) {
-  const [firstTimeUser, setFirstTimeUser] = useLocalStorage(
-    "FIRST_TIME_USER",
-    true,
-  );
   const pathName = usePathname();
   const activeBanners = getBannerCount(honeyName, pathName);
   return (
@@ -66,7 +61,7 @@ export default function RootLayout(props: { children: React.ReactNode }) {
         )}
       >
         {" "}
-        <TermOfUseModal open={firstTimeUser} setOpen={setFirstTimeUser} />
+        <TermOfUseModal />
         <ApolloProvider client={honeyClient}>
           <BeraWagmi>
             <Header

--- a/apps/hub/src/app/layout.tsx
+++ b/apps/hub/src/app/layout.tsx
@@ -16,7 +16,6 @@ import {
 import { cn } from "@bera/ui";
 import { Analytics } from "@vercel/analytics/react";
 import { Toaster } from "react-hot-toast";
-import { useLocalStorage } from "usehooks-ts";
 
 import Providers from "./Providers";
 import { navItems } from "./config";
@@ -28,11 +27,6 @@ const fontSans = IBM_Plex_Sans({
 });
 
 export default function RootLayout(props: { children: React.ReactNode }) {
-  const [firstTimeUser, setFirstTimeUser] = useLocalStorage(
-    "FIRST_TIME_USER",
-    true,
-  );
-
   const pathName = usePathname();
   const activeBanners = getBannerCount(bgtName, pathName);
 
@@ -55,7 +49,7 @@ export default function RootLayout(props: { children: React.ReactNode }) {
       <body
         className={cn("min-h-screen font-sans antialiased", fontSans.variable)}
       >
-        <TermOfUseModal open={firstTimeUser} setOpen={setFirstTimeUser} />
+        <TermOfUseModal />
         <Providers>
           <div className="relative flex min-h-screen w-full flex-col overflow-hidden">
             <div className="z-[100]">

--- a/apps/lend/src/app/layout.tsx
+++ b/apps/lend/src/app/layout.tsx
@@ -1,13 +1,11 @@
-"use client";
-
 import "@bera/ui/styles.css";
 import "../styles/globals.css";
 import { IBM_Plex_Sans } from "next/font/google";
-import { usePathname } from "next/navigation";
 import Script from "next/script";
 import { lendName } from "@bera/config";
 import {
   Header,
+  MainWithBanners,
   TailwindIndicator,
   TermOfUseModal,
   getBannerCount,
@@ -26,8 +24,6 @@ const fontSans = IBM_Plex_Sans({
 });
 
 export default function RootLayout(props: { children: React.ReactNode }) {
-  const pathName = usePathname();
-  const activeBanners = getBannerCount(lendName, pathName);
   return (
     <html lang="en">
       <Script
@@ -54,12 +50,9 @@ export default function RootLayout(props: { children: React.ReactNode }) {
           </div>
           <div className="relative flex min-h-screen w-full flex-col overflow-hidden">
             <Header navItems={navItems} appName={lendName} />
-            <main
-              className="w-full"
-              style={{ paddingTop: `${48 * activeBanners + 80}px` }}
-            >
+            <MainWithBanners appName={lendName} paddingTop={80}>
               {props.children}
-            </main>
+            </MainWithBanners>
           </div>
           <TailwindIndicator />
           <Analytics />

--- a/apps/lend/src/app/layout.tsx
+++ b/apps/lend/src/app/layout.tsx
@@ -3,8 +3,8 @@
 import "@bera/ui/styles.css";
 import "../styles/globals.css";
 import { IBM_Plex_Sans } from "next/font/google";
-import Script from "next/script";
 import { usePathname } from "next/navigation";
+import Script from "next/script";
 import { lendName } from "@bera/config";
 import {
   Header,
@@ -15,7 +15,6 @@ import {
 import { cn } from "@bera/ui";
 import { Analytics } from "@vercel/analytics/react";
 import { Toaster } from "react-hot-toast";
-import { useLocalStorage } from "usehooks-ts";
 
 import Providers from "./Providers";
 import { navItems } from "./config";
@@ -27,10 +26,6 @@ const fontSans = IBM_Plex_Sans({
 });
 
 export default function RootLayout(props: { children: React.ReactNode }) {
-  const [firstTimeUser, setFirstTimeUser] = useLocalStorage(
-    "FIRST_TIME_USER",
-    true,
-  );
   const pathName = usePathname();
   const activeBanners = getBannerCount(lendName, pathName);
   return (
@@ -52,7 +47,7 @@ export default function RootLayout(props: { children: React.ReactNode }) {
       <body
         className={cn("bg-background font-sans antialiased", fontSans.variable)}
       >
-        <TermOfUseModal open={firstTimeUser} setOpen={setFirstTimeUser} />
+        <TermOfUseModal />
         <Providers>
           <div className="z-[100]">
             <Toaster position="bottom-right" />

--- a/apps/perp/src/app/Providers.tsx
+++ b/apps/perp/src/app/Providers.tsx
@@ -7,9 +7,12 @@ import { ThemeProvider } from "next-themes";
 import { PriceContextProvider } from "~/context/price-context";
 import { TableContextProvider } from "~/context/table-context";
 
-export default function Providers({ children }: PropsWithChildren<any>) {
+export default function Providers({
+  children,
+  initialWagmiState,
+}: PropsWithChildren<any>) {
   return (
-    <BeraWagmi>
+    <BeraWagmi initialWagmiState={initialWagmiState}>
       <ThemeProvider attribute="class" defaultTheme="dark" enableSystem>
         <PriceContextProvider>
           <TableContextProvider>{children}</TableContextProvider>

--- a/apps/perp/src/app/Providers.tsx
+++ b/apps/perp/src/app/Providers.tsx
@@ -10,7 +10,9 @@ import { TableContextProvider } from "~/context/table-context";
 export default function Providers({
   children,
   initialWagmiState,
-}: PropsWithChildren<any>) {
+}: PropsWithChildren<{
+  initialWagmiState?: any;
+}>) {
   return (
     <BeraWagmi initialWagmiState={initialWagmiState}>
       <ThemeProvider attribute="class" defaultTheme="dark" enableSystem>

--- a/apps/perp/src/app/layout.tsx
+++ b/apps/perp/src/app/layout.tsx
@@ -16,6 +16,7 @@ import { cn } from "@bera/ui";
 import { Analytics } from "@vercel/analytics/react";
 import { Toaster } from "react-hot-toast";
 import { useLocalStorage } from "usehooks-ts";
+import { cookieToInitialState } from "wagmi";
 
 import Providers from "./Providers";
 import { navItems } from "./config";

--- a/apps/perp/src/app/layout.tsx
+++ b/apps/perp/src/app/layout.tsx
@@ -1,16 +1,13 @@
-"use client";
-
 import "@bera/ui/styles.css";
 import "../styles/globals.css";
 import { IBM_Plex_Sans } from "next/font/google";
-import { usePathname } from "next/navigation";
 import Script from "next/script";
 import { perpsName } from "@bera/config";
 import {
   Header,
+  MainWithBanners,
   TailwindIndicator,
   TermOfUseModal,
-  getBannerCount,
 } from "@bera/shared-ui";
 import { cn } from "@bera/ui";
 import { Analytics } from "@vercel/analytics/react";
@@ -27,9 +24,6 @@ const fontSans = IBM_Plex_Sans({
 });
 
 export default function RootLayout(props: { children: React.ReactNode }) {
-  const pathName = usePathname();
-  const activeBanners = getBannerCount(perpsName, pathName);
-
   return (
     <html lang="en">
       <Script
@@ -56,12 +50,9 @@ export default function RootLayout(props: { children: React.ReactNode }) {
           </div>
           <div className="relative flex min-h-screen w-full flex-col overflow-hidden">
             <Header navItems={navItems} appName={perpsName} />
-            <main
-              className="w-full"
-              style={{ paddingTop: `${48 * activeBanners + 72}px` }}
-            >
+            <MainWithBanners appName={perpsName}>
               {props.children}
-            </main>
+            </MainWithBanners>
             <Toaster position="bottom-right" />
           </div>
           <TailwindIndicator />

--- a/apps/perp/src/app/layout.tsx
+++ b/apps/perp/src/app/layout.tsx
@@ -15,7 +15,6 @@ import {
 import { cn } from "@bera/ui";
 import { Analytics } from "@vercel/analytics/react";
 import { Toaster } from "react-hot-toast";
-import { useLocalStorage } from "usehooks-ts";
 import { cookieToInitialState } from "wagmi";
 
 import Providers from "./Providers";
@@ -28,10 +27,6 @@ const fontSans = IBM_Plex_Sans({
 });
 
 export default function RootLayout(props: { children: React.ReactNode }) {
-  const [firstTimeUser, setFirstTimeUser] = useLocalStorage(
-    "FIRST_TIME_USER",
-    true,
-  );
   const pathName = usePathname();
   const activeBanners = getBannerCount(perpsName, pathName);
 
@@ -54,7 +49,7 @@ export default function RootLayout(props: { children: React.ReactNode }) {
       <body
         className={cn("bg-background font-sans antialiased", fontSans.variable)}
       >
-        <TermOfUseModal open={firstTimeUser} setOpen={setFirstTimeUser} />
+        <TermOfUseModal />
         <Providers>
           <div className="z-[100]">
             <Toaster position="bottom-right" />

--- a/packages/shared-ui/src/index.ts
+++ b/packages/shared-ui/src/index.ts
@@ -40,6 +40,7 @@ export { ApproveButton } from "./approve-button";
 export { DynamicRewardBtn } from "./dynamic-reward-btn";
 export { Documentation } from "./documentation";
 export { MainNav } from "./main-nav";
+export { MainWithBanners } from "./main-with-banners";
 export { MobileDropdown } from "./mobile-nav";
 export { TermsOfUse, PrivacyPolicy, TermOfUseModal } from "./terms-of-use";
 export { AccessDenyModal, AccessDeny } from "./access-deny";

--- a/packages/shared-ui/src/main-with-banners.tsx
+++ b/packages/shared-ui/src/main-with-banners.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { FC, HTMLProps, PropsWithChildren } from "react";
+import { usePathname } from "next/navigation";
+import { cn } from "@bera/ui";
+
+import { getBannerCount } from "./utils";
+
+export const MainWithBanners: FC<
+  PropsWithChildren<{ appName: string; paddingTop?: number }> &
+    HTMLProps<HTMLDivElement>
+> = ({ appName, children, paddingTop = 72, className, ...props }) => {
+  const pathName = usePathname();
+  const activeBanners = getBannerCount(appName, pathName);
+
+  return (
+    <main
+      className={cn("w-full", className)}
+      {...props}
+      style={{
+        paddingTop: `${48 * activeBanners + paddingTop}px`,
+        ...props.style,
+      }}
+    >
+      {children}
+    </main>
+  );
+};

--- a/packages/shared-ui/src/terms-of-use.tsx
+++ b/packages/shared-ui/src/terms-of-use.tsx
@@ -11,6 +11,7 @@ import {
   DialogTitle,
 } from "@bera/ui/dialog";
 import { Icons } from "@bera/ui/icons";
+import { useLocalStorage } from "usehooks-ts";
 
 import Privacy from "./utils/privacy-policy.json";
 import Terms from "./utils/terms-of-use.json";
@@ -127,13 +128,8 @@ export const PrivacyPolicy = () => {
   );
 };
 
-export const TermOfUseModal = ({
-  open,
-  setOpen,
-}: {
-  open: boolean;
-  setOpen: (open: boolean) => void;
-}) => {
+export const TermOfUseModal = () => {
+  const [open, setOpen] = useLocalStorage("FIRST_TIME_USER", true);
   const [checked, setChecked] = useState(false);
   const [alert, setAlert] = useState(false);
   return (

--- a/packages/wagmi/package.json
+++ b/packages/wagmi/package.json
@@ -5,9 +5,21 @@
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "type": "module",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./*": {
+      "types": "./dist/*/index.d.ts",
+      "import": "./dist/*/index.js",
+      "require": "./dist/*/index.js",
+      "default": "./dist/*/index.js"
+    }
+  },
   "scripts": {
     "build": "tsup src",
     "clean": "git clean -xdf dist .turbo node_modules",

--- a/packages/wagmi/src/config/defaultBeraJsConfig.ts
+++ b/packages/wagmi/src/config/defaultBeraJsConfig.ts
@@ -79,9 +79,9 @@ export const wagmiConfig = createConfig({
   chains: [defaultBeraNetworkConfig.chain],
   multiInjectedProviderDiscovery: false,
   ssr: true,
-  storage: createStorage({
-    storage: cookieStorage,
-  }),
+  // storage: createStorage({
+  //   storage: cookieStorage,
+  // }),
 
   batch: {
     /**

--- a/packages/wagmi/src/config/defaultBeraJsConfig.ts
+++ b/packages/wagmi/src/config/defaultBeraJsConfig.ts
@@ -16,7 +16,7 @@ import { EvmNetwork } from "@dynamic-labs/sdk-react-core";
 import { type Chain } from "viem";
 import { cookieStorage, createConfig, createStorage, http } from "wagmi";
 
-import { NetworkConfig } from "~/context/context";
+import type { NetworkConfig } from "~/context/context";
 
 const BeraChain: Chain = {
   id: chainId,

--- a/packages/wagmi/src/config/defaultBeraJsConfig.ts
+++ b/packages/wagmi/src/config/defaultBeraJsConfig.ts
@@ -14,7 +14,7 @@ import {
 } from "@bera/config";
 import { EvmNetwork } from "@dynamic-labs/sdk-react-core";
 import { type Chain } from "viem";
-import { createConfig, http } from "wagmi";
+import { cookieStorage, createConfig, createStorage, http } from "wagmi";
 
 import { NetworkConfig } from "~/context/context";
 
@@ -78,7 +78,11 @@ export const defaultBeraNetworkConfig: NetworkConfig = {
 export const wagmiConfig = createConfig({
   chains: [defaultBeraNetworkConfig.chain],
   multiInjectedProviderDiscovery: false,
-  ssr: false,
+  ssr: true,
+  storage: createStorage({
+    storage: cookieStorage,
+  }),
+
   batch: {
     /**
      * @see https://viem.sh/docs/clients/public#batchmulticallwait-optional

--- a/packages/wagmi/src/context/context.tsx
+++ b/packages/wagmi/src/context/context.tsx
@@ -30,6 +30,7 @@ export interface NetworkConfig {
 
 interface IBeraConfig extends PropsWithChildren {
   darkTheme?: boolean;
+  initialWagmiState?: any;
 }
 
 export interface IBeraConfigAPI {
@@ -45,6 +46,7 @@ const queryClient = new QueryClient();
 const Provider: React.FC<IBeraConfig> = ({
   children,
   darkTheme = undefined,
+  initialWagmiState = {},
 }) => {
   const { theme: nextTheme } = useTheme();
   const theme: ThemeSetting =
@@ -71,7 +73,7 @@ const Provider: React.FC<IBeraConfig> = ({
         }}
         theme={theme ?? "auto"}
       >
-        <WagmiProvider config={wagmiConfig}>
+        <WagmiProvider config={wagmiConfig} initialState={initialWagmiState}>
           <QueryClientProvider client={queryClient}>
             <DynamicWagmiConnector>
               <BeraJsProvider configOverride={undefined}>


### PR DESCRIPTION
Hi,

this is a PR required before other improvments. I basically moved whatever needed use client in components outside `layout.ts`, where possible.

Here's a wrap up:

- `TermOfUseModal` uses localStorage internally now
- `activeBanners` is computed inside `MainWithBanners` which internally calls usePathname
- `initialWagmiState` is added but not used in this PR
- `layout.ts` files are now react server components, and can be async 
