### PR TITLE
fix: dynamic warn 'chain is missing in wagmi config'

### DIFF
--- a/packages/wagmi/src/context/context.tsx
+++ b/packages/wagmi/src/context/context.tsx
@@ -7,7 +7,6 @@ import { EthereumWalletConnectors } from "@dynamic-labs/ethereum";
 import {
   DynamicContextProvider,
   EvmNetwork,
-  mergeNetworks,
   SortWallets,
 } from "@dynamic-labs/sdk-react-core";
 import { ThemeSetting } from "@dynamic-labs/sdk-react-core/src/lib/context/ThemeContext";
@@ -53,8 +52,8 @@ const Provider: React.FC<IBeraConfig> = ({
         ? "auto"
         : nextTheme
       : darkTheme
-        ? "dark"
-        : "light";
+      ? "dark"
+      : "light";
 
   return (
     <BeraWagmi.Provider value={{ networkConfig: defaultBeraNetworkConfig }}>
@@ -64,8 +63,7 @@ const Provider: React.FC<IBeraConfig> = ({
           environmentId: dynamicWalletKey,
           walletConnectors: [EthereumWalletConnectors],
           overrides: {
-            evmNetworks: (networks) =>
-              mergeNetworks([defaultBeraNetworkConfig.evmNetwork], networks),
+            evmNetworks: () => [defaultBeraNetworkConfig.evmNetwork],
           },
           walletsFilter: SortWallets(["metamask", "binance"]),
         }}


### PR DESCRIPTION
Dynamic kept logging this warn message. I think that happened because there was Ethereum set as project chain since bArtio wasn't listed at the time. This PR refactors the code to ignore all previously set chains.

<img width="320" alt="Screenshot 2024-08-28 at 15 43 39" src="https://github.com/user-attachments/assets/5ae85aa3-1747-4316-96ad-1398c9bf929f">
