### PR TITLE
Fixed RSC layout bug

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,5 +12,5 @@
     "titleBar.activeBackground": "#134A18",
     "titleBar.activeForeground": "#F3FCF4"
   },
-  "conventionalCommits.scopes": ["perp", "bend"]
+  "conventionalCommits.scopes": ["perp", "bend", "honey"]
 }

--- a/apps/honey/src/app/layout.tsx
+++ b/apps/honey/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import "../styles/globals.css";
 import { IBM_Plex_Sans, Jua } from "next/font/google";
 import Script from "next/script";
-import { honeyName, honeyUrl } from "@bera/config";
+import { honeyName } from "@bera/config";
 import {
   Footer,
   Header,
@@ -14,7 +14,6 @@ import { Toaster } from "react-hot-toast";
 
 import { mobileNavItems, navItems } from "./config";
 import HoneyProviders from "~/components/honey-providers";
-import { Metadata } from "next";
 
 const fontSans = IBM_Plex_Sans({
   weight: ["400", "500", "600", "700"],
@@ -27,10 +26,6 @@ const fontHoney = Jua({
   variable: "--font-honey",
   subsets: ["latin"],
 });
-
-export const metadata: Metadata = {
-  metadataBase: new URL(honeyUrl),
-};
 
 export default function RootLayout(props: { children: React.ReactNode }) {
   return (

--- a/apps/honey/src/app/layout.tsx
+++ b/apps/honey/src/app/layout.tsx
@@ -1,12 +1,7 @@
-"use client";
-
-import "@bera/ui/styles.css";
 import "../styles/globals.css";
 import { IBM_Plex_Sans, Jua } from "next/font/google";
 import Script from "next/script";
-import { ApolloProvider } from "@apollo/client";
 import { honeyName } from "@bera/config";
-import { honeyClient } from "@bera/graphql";
 import {
   Footer,
   Header,
@@ -15,11 +10,10 @@ import {
   TermOfUseModal,
 } from "@bera/shared-ui";
 import { cn } from "@bera/ui";
-import { BeraWagmi } from "@bera/wagmi";
-import { Analytics } from "@vercel/analytics/react";
 import { Toaster } from "react-hot-toast";
 
 import { mobileNavItems, navItems } from "./config";
+import HoneyProviders from "~/components/honey-providers";
 
 const fontSans = IBM_Plex_Sans({
   weight: ["400", "500", "600", "700"],
@@ -59,23 +53,20 @@ export default function RootLayout(props: { children: React.ReactNode }) {
       >
         {" "}
         <TermOfUseModal />
-        <ApolloProvider client={honeyClient}>
-          <BeraWagmi>
-            <Header
-              isHoney
-              navItems={navItems}
-              mobileNavItems={mobileNavItems}
-              appName={honeyName}
-            />
-            <MainWithBanners className="pt-start" appName={honeyName}>
-              {props.children}
-            </MainWithBanners>
-            <Toaster position="bottom-right" />
-            <Footer />
-            <TailwindIndicator />
-            <Analytics />
-          </BeraWagmi>
-        </ApolloProvider>
+        <HoneyProviders>
+          <Header
+            isHoney
+            navItems={navItems}
+            mobileNavItems={mobileNavItems}
+            appName={honeyName}
+          />
+          <MainWithBanners className="pt-start" appName={honeyName}>
+            {props.children}
+          </MainWithBanners>
+          <Toaster position="bottom-right" />
+          <Footer />
+          <TailwindIndicator />
+        </HoneyProviders>
       </body>
     </html>
   );

--- a/apps/honey/src/app/layout.tsx
+++ b/apps/honey/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import "../styles/globals.css";
 import { IBM_Plex_Sans, Jua } from "next/font/google";
 import Script from "next/script";
-import { honeyName } from "@bera/config";
+import { honeyName, honeyUrl } from "@bera/config";
 import {
   Footer,
   Header,
@@ -14,6 +14,7 @@ import { Toaster } from "react-hot-toast";
 
 import { mobileNavItems, navItems } from "./config";
 import HoneyProviders from "~/components/honey-providers";
+import { Metadata } from "next";
 
 const fontSans = IBM_Plex_Sans({
   weight: ["400", "500", "600", "700"],
@@ -26,6 +27,10 @@ const fontHoney = Jua({
   variable: "--font-honey",
   subsets: ["latin"],
 });
+
+export const metadata: Metadata = {
+  metadataBase: new URL(honeyUrl),
+};
 
 export default function RootLayout(props: { children: React.ReactNode }) {
   return (

--- a/apps/honey/src/components/honey-providers.tsx
+++ b/apps/honey/src/components/honey-providers.tsx
@@ -1,0 +1,18 @@
+"use client";
+import { ApolloProvider } from "@apollo/client";
+import { honeyClient } from "@bera/graphql";
+import { Analytics } from "@vercel/analytics/react";
+import { BeraWagmi } from "@bera/wagmi";
+
+export default function HoneyProviders({
+  children,
+}: { children: React.ReactNode }) {
+  return (
+    <ApolloProvider client={honeyClient}>
+      <BeraWagmi>
+        {children}
+        <Analytics />
+      </BeraWagmi>
+    </ApolloProvider>
+  );
+}

--- a/apps/hub/src/app/layout.tsx
+++ b/apps/hub/src/app/layout.tsx
@@ -3,15 +3,14 @@
 import "@bera/ui/styles.css";
 import "../styles/globals.css";
 import { IBM_Plex_Sans } from "next/font/google";
-import { usePathname } from "next/navigation";
 import Script from "next/script";
 import { bgtName } from "@bera/config";
 import {
   Footer,
   Header,
+  MainWithBanners,
   TailwindIndicator,
   TermOfUseModal,
-  getBannerCount,
 } from "@bera/shared-ui";
 import { cn } from "@bera/ui";
 import { Analytics } from "@vercel/analytics/react";
@@ -27,9 +26,6 @@ const fontSans = IBM_Plex_Sans({
 });
 
 export default function RootLayout(props: { children: React.ReactNode }) {
-  const pathName = usePathname();
-  const activeBanners = getBannerCount(bgtName, pathName);
-
   return (
     <html lang="en" className="bg-background">
       <Script
@@ -57,12 +53,14 @@ export default function RootLayout(props: { children: React.ReactNode }) {
             </div>
             <div className="z-10 flex-1">
               <Header navItems={navItems} appName={bgtName} />
-              <main
-                className="w-full pt-start"
-                style={{ paddingTop: `${150 + 50 * activeBanners}px` }}
+              <MainWithBanners
+                className="pt-start"
+                paddingTop={150}
+                multiplier={50}
+                appName={bgtName}
               >
                 {props.children}
-              </main>
+              </MainWithBanners>
             </div>
             <Footer />
           </div>

--- a/apps/hub/src/app/layout.tsx
+++ b/apps/hub/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import "../styles/globals.css";
 import { IBM_Plex_Sans } from "next/font/google";
 import Script from "next/script";
-import { bgtName } from "@bera/config";
+import { bgtName, hubUrl } from "@bera/config";
 import {
   Footer,
   Header,
@@ -15,12 +15,17 @@ import { Toaster } from "react-hot-toast";
 
 import Providers from "./Providers";
 import { navItems } from "./config";
+import { Metadata } from "next";
 
 const fontSans = IBM_Plex_Sans({
   weight: ["400", "500", "600", "700"],
   variable: "--font-sans",
   subsets: ["latin"],
 });
+
+export const metadata: Metadata = {
+  metadataBase: new URL(hubUrl),
+};
 
 export default function RootLayout(props: { children: React.ReactNode }) {
   return (

--- a/apps/hub/src/app/layout.tsx
+++ b/apps/hub/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import "../styles/globals.css";
 import { IBM_Plex_Sans } from "next/font/google";
 import Script from "next/script";
-import { bgtName, hubUrl } from "@bera/config";
+import { bgtName } from "@bera/config";
 import {
   Footer,
   Header,
@@ -15,17 +15,12 @@ import { Toaster } from "react-hot-toast";
 
 import Providers from "./Providers";
 import { navItems } from "./config";
-import { Metadata } from "next";
 
 const fontSans = IBM_Plex_Sans({
   weight: ["400", "500", "600", "700"],
   variable: "--font-sans",
   subsets: ["latin"],
 });
-
-export const metadata: Metadata = {
-  metadataBase: new URL(hubUrl),
-};
 
 export default function RootLayout(props: { children: React.ReactNode }) {
   return (

--- a/apps/hub/src/app/layout.tsx
+++ b/apps/hub/src/app/layout.tsx
@@ -1,6 +1,3 @@
-"use client";
-
-import "@bera/ui/styles.css";
 import "../styles/globals.css";
 import { IBM_Plex_Sans } from "next/font/google";
 import Script from "next/script";

--- a/apps/lend/src/app/layout.tsx
+++ b/apps/lend/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import "../styles/globals.css";
 import { IBM_Plex_Sans } from "next/font/google";
 import Script from "next/script";
-import { lendName, lendUrl } from "@bera/config";
+import { lendName } from "@bera/config";
 import {
   Header,
   MainWithBanners,
@@ -15,17 +15,12 @@ import { Toaster } from "react-hot-toast";
 
 import Providers from "./Providers";
 import { navItems } from "./config";
-import { Metadata } from "next";
 
 const fontSans = IBM_Plex_Sans({
   weight: ["400", "500", "600", "700"],
   variable: "--font-sans",
   subsets: ["latin"],
 });
-
-export const metadata: Metadata = {
-  metadataBase: new URL(lendUrl),
-};
 
 export default function RootLayout(props: { children: React.ReactNode }) {
   return (

--- a/apps/lend/src/app/layout.tsx
+++ b/apps/lend/src/app/layout.tsx
@@ -1,6 +1,3 @@
-"use client";
-
-import "@bera/ui/styles.css";
 import "../styles/globals.css";
 import { IBM_Plex_Sans } from "next/font/google";
 import Script from "next/script";

--- a/apps/lend/src/app/layout.tsx
+++ b/apps/lend/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import "../styles/globals.css";
 import { IBM_Plex_Sans } from "next/font/google";
 import Script from "next/script";
-import { lendName } from "@bera/config";
+import { lendName, lendUrl } from "@bera/config";
 import {
   Header,
   MainWithBanners,
@@ -15,12 +15,17 @@ import { Toaster } from "react-hot-toast";
 
 import Providers from "./Providers";
 import { navItems } from "./config";
+import { Metadata } from "next";
 
 const fontSans = IBM_Plex_Sans({
   weight: ["400", "500", "600", "700"],
   variable: "--font-sans",
   subsets: ["latin"],
 });
+
+export const metadata: Metadata = {
+  metadataBase: new URL(lendUrl),
+};
 
 export default function RootLayout(props: { children: React.ReactNode }) {
   return (

--- a/apps/perp/src/app/layout.tsx
+++ b/apps/perp/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import "../styles/globals.css";
 import { IBM_Plex_Sans } from "next/font/google";
 import Script from "next/script";
-import { perpsName, perpsUrl } from "@bera/config";
+import { perpsName } from "@bera/config";
 import {
   Header,
   MainWithBanners,
@@ -14,17 +14,12 @@ import { Toaster } from "react-hot-toast";
 
 import Providers from "./Providers";
 import { navItems } from "./config";
-import { Metadata } from "next";
 
 const fontSans = IBM_Plex_Sans({
   weight: ["400", "500", "600", "700"],
   variable: "--font-sans",
   subsets: ["latin"],
 });
-
-export const metadata: Metadata = {
-  metadataBase: new URL(perpsUrl),
-};
 
 export default function RootLayout(props: { children: React.ReactNode }) {
   return (

--- a/apps/perp/src/app/layout.tsx
+++ b/apps/perp/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import "../styles/globals.css";
 import { IBM_Plex_Sans } from "next/font/google";
 import Script from "next/script";
-import { perpsName } from "@bera/config";
+import { perpsName, perpsUrl } from "@bera/config";
 import {
   Header,
   MainWithBanners,
@@ -14,12 +14,17 @@ import { Toaster } from "react-hot-toast";
 
 import Providers from "./Providers";
 import { navItems } from "./config";
+import { Metadata } from "next";
 
 const fontSans = IBM_Plex_Sans({
   weight: ["400", "500", "600", "700"],
   variable: "--font-sans",
   subsets: ["latin"],
 });
+
+export const metadata: Metadata = {
+  metadataBase: new URL(perpsUrl),
+};
 
 export default function RootLayout(props: { children: React.ReactNode }) {
   return (

--- a/apps/perp/src/app/layout.tsx
+++ b/apps/perp/src/app/layout.tsx
@@ -1,6 +1,3 @@
-"use client";
-
-import "@bera/ui/styles.css";
 import "../styles/globals.css";
 import { IBM_Plex_Sans } from "next/font/google";
 import Script from "next/script";

--- a/packages/shared-ui/src/main-nav.tsx
+++ b/packages/shared-ui/src/main-nav.tsx
@@ -37,14 +37,14 @@ export function MainNav({
                   </NavigationMenuTrigger>
                   <NavigationMenuContent>
                     <ul className="flex w-[404px] flex-col gap-1 p-4">
-                      {item.children.map((component: any) => (
+                      {item.children.map((component: any, idx: number) => (
                         <NavListItem
                           onClick={() => {
                             track(
                               `Navbar - "${item.title}" > "${component.title}" Clicked`,
                             );
                           }}
-                          key={component.title}
+                          key={component.title + idx}
                           title={component.title}
                           href={component.href}
                           type={component.type}

--- a/packages/shared-ui/src/main-with-banners.tsx
+++ b/packages/shared-ui/src/main-with-banners.tsx
@@ -7,9 +7,20 @@ import { cn } from "@bera/ui";
 import { getBannerCount } from "./utils";
 
 export const MainWithBanners: FC<
-  PropsWithChildren<{ appName: string; paddingTop?: number }> &
+  PropsWithChildren<{
+    appName: string;
+    paddingTop?: number;
+    multiplier?: number;
+  }> &
     HTMLProps<HTMLDivElement>
-> = ({ appName, children, paddingTop = 72, className, ...props }) => {
+> = ({
+  appName,
+  children,
+  paddingTop = 72,
+  multiplier = 48,
+  className,
+  ...props
+}) => {
   const pathName = usePathname();
   const activeBanners = getBannerCount(appName, pathName);
 
@@ -18,7 +29,7 @@ export const MainWithBanners: FC<
       className={cn("w-full", className)}
       {...props}
       style={{
-        paddingTop: `${48 * activeBanners + paddingTop}px`,
+        paddingTop: `${multiplier * activeBanners + paddingTop}px`,
         ...props.style,
       }}
     >

--- a/packages/shared-ui/src/mobile-nav.tsx
+++ b/packages/shared-ui/src/mobile-nav.tsx
@@ -38,14 +38,14 @@ export function MobileDropdown({ navItems }: { navItems: any[] }) {
       </PopoverTrigger>
       <PopoverContent className="z-40 mt-2 h-[calc(100vh-4rem)] w-screen animate-none rounded-none border-none transition-transform">
         <ScrollArea className="h-full py-8">
-          {navItems.map(({ href, title, children }) => {
+          {navItems.map(({ href, title, children }, idx) => {
             if (href === "#" && children) {
               return (
-                <NavigationMenu key={href}>
+                <NavigationMenu key={idx}>
                   <ul className="flex w-full flex-col gap-1 p-4" key={href}>
-                    {children.map((component: any) => (
+                    {children.map((component: any, idx: number) => (
                       <NavListItem
-                        key={component.title}
+                        key={component.title + idx}
                         title={component.title}
                         href={component.href}
                         type={component.type}
@@ -60,7 +60,7 @@ export function MobileDropdown({ navItems }: { navItems: any[] }) {
             }
             return (
               <Link
-                key={href}
+                key={idx}
                 onClick={() => setIsOpen(false)}
                 href={{ pathname: href }}
                 className="flex p-4 font-medium text-foreground transition-colors hover:text-primary"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -85,7 +85,6 @@
   },
   "exports": {
     "./package.json": "./package.json",
-    "./styles.css": "./dist/index.css",
     ".": {
       "import": "./dist/index.mjs",
       "types": "./dist/index.d.ts"

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,3 +1,1 @@
-import "./styles.css";
-
 export { cn } from "./utils/cn";

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -1,3 +1,0 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;

--- a/packages/ui/tsup.config.ts
+++ b/packages/ui/tsup.config.ts
@@ -37,7 +37,7 @@ const client = [
   "./src/slider.tsx",
   "./src/chart.tsx",
   "./src/recharts.tsx",
-  "./src/pagination.tsx"
+  "./src/pagination.tsx",
 ];
 
 const server = [
@@ -82,7 +82,6 @@ export default defineConfig((opts) => {
         ) as PackageJson;
         pkgJson.exports = {
           "./package.json": "./package.json",
-          "./styles.css": "./dist/index.css",
           ".": {
             import: "./dist/index.mjs",
             types: "./dist/index.d.ts",


### PR DESCRIPTION
BM BM, i (kinda) figured out why removing use client on layouts would break styles.

We were importing tailwind twice and this would mess up with responsive class as they would lose priority in css. Still dont know why use client would fix it but lgtm now. Please check ahah

This lets us use layout.ts features like metadatas etc...

