### PR TITLE
fix(bgt): update station to fetch all vaults for vault dictionary

### DIFF
--- a/apps/bgt-station/src/components/gauge-header-widget.tsx
+++ b/apps/bgt-station/src/components/gauge-header-widget.tsx
@@ -7,11 +7,13 @@ export const GaugeHeaderWidget = ({
   address,
   className,
 }: {
-  address: Address;
+  address?: Address;
   className?: string;
 }) => {
-  const { gaugeDictionary, isLoading } = usePollGauges();
-  const gauge = gaugeDictionary?.[address];
+  const { gaugeDictionary, isLoading } = usePollGauges({
+    pageSize: 9999,
+  });
+  const gauge = gaugeDictionary?.[address ?? ""];
 
   const { data } = useTokens();
   const tokenList = data?.tokenList ?? [];
@@ -19,6 +21,7 @@ export const GaugeHeaderWidget = ({
   if (tokenList[0] && tokenList[1]) {
     list = [tokenList[0], tokenList[1]];
   }
+
   return (
     <>
       {isLoading || !gauge ? (
@@ -37,7 +40,7 @@ export const GaugeHeaderWidget = ({
             />
             {gauge.metadata?.name ?? truncateHash(gauge.id)}
           </div>
-          <div className="flex items-center gap-1 text-sm font-medium leading-5 ml-2">
+          <div className="ml-2 flex items-center gap-1 text-sm font-medium leading-5">
             <MarketIcon market={gauge.metadata?.product ?? "OTHER"} size="md" />
             {gauge.metadata?.product ?? "OTHER"}
           </div>

--- a/packages/shared-ui/src/gauge-icon.tsx
+++ b/packages/shared-ui/src/gauge-icon.tsx
@@ -42,7 +42,10 @@ export const GaugeIcon = ({
   size,
   ...props
 }: IconProps) => {
-  const { gaugeDictionary } = usePollGauges();
+  // This returns all gauges, not just the ones for the validator or specific pages
+  const { gaugeDictionary } = usePollGauges({
+    pageSize: 9999,
+  });
   const img = useMemo(
     () => gaugeDictionary?.[address]?.metadata?.logoURI ?? "",
     [address],
@@ -55,7 +58,7 @@ export const GaugeIcon = ({
         alt={address}
       />
       <AvatarFallback>
-        <Icons.gauge className="w-full h-full p-[15%]" />
+        <Icons.gauge className="h-full w-full p-[15%]" />
       </AvatarFallback>
     </Avatar>
   );


### PR DESCRIPTION
Wanted to properly implement this where every time we fetch vaults, that's the new directory and we don't need to refetch but there's some use cases where we don't have a pre-selected amount of gauges so just set the default to '9999' vaults when trying to use the 'vault dictionary'.