### PR TITLE
Create CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,42 @@
+## How to contribute to Monobera
+
+#### **Did you find a bug?**
+
+* **Do not open up a GitHub issue if the bug is a security vulnerability
+  in Monobera**, and instead reach out our mods on our Discord server.
+
+* **Ensure the bug was not already reported** by searching on GitHub under [Issues](https://github.com/berachain/monobera/issues).
+
+* If you're unable to find an open issue addressing the problem, [open a new one](https://github.com/berachain/monobera/issues/new). Be sure to include a **title and clear description**, as much relevant information as possible, and a **code sample** or an **executable test case** demonstrating the expected behavior that is not occurring.
+
+#### **Did you write a patch that fixes a bug?**
+
+* Open a new GitHub pull request with the patch.
+
+* Ensure the PR description clearly describes the problem and solution. Include the relevant issue number if applicable.
+
+#### **Did you fix whitespace, format code, or make a purely cosmetic patch?**
+
+Changes that are cosmetic in nature and do not add anything substantial to the stability, functionality, or testability of this repo will generally not be accepted (we totally agree with the reasons outline in this [Ruby on Rails pull request](https://github.com/rails/rails/pull/13771#issuecomment-32746700)).
+
+<!-- #### **Do you intend to add a new feature or change an existing one?**
+
+* Suggest your change in the [rubyonrails-core mailing list](https://discuss.rubyonrails.org/c/rubyonrails-core) and start writing code.
+
+* Do not open an issue on GitHub until you have collected positive feedback about the change. GitHub issues are primarily intended for bug reports and fixes.
+
+* We generally reject changes to Active Support core extensions. Those change should be proposed in the [Ruby issue tracker instead](https://bugs.ruby-lang.org/issues), as we don't want to conflict with future versions of Ruby.
+
+#### **Do you have questions about the source code?**
+
+* Ask any question about how to use Ruby on Rails in the [rubyonrails-talk mailing list](https://discuss.rubyonrails.org/c/rubyonrails-talk).
+
+#### **Do you want to contribute to the Rails documentation?**
+
+* Please read [Contributing to the Rails Documentation](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation).
+
+Ruby on Rails is a volunteer effort. We encourage you to pitch in and join [the team](https://contributors.rubyonrails.org)! -->
+
+Thanks!
+
+Berachain Team 🐻⛓️


### PR DESCRIPTION
I think we should have a contributors guideline, in particular to avoid prs on the documentation/readme files. 

I copied and edited the one from ruby on rail, as it was suggested by GitHub docs.

I left some parts of it commented as we might need it in the future.

