### PR TITLE
fix: handle wrong type inputValue and add tests

### DIFF
--- a/packages/berajs/src/utils/formatInputTokenValue.test.ts
+++ b/packages/berajs/src/utils/formatInputTokenValue.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "@jest/globals";
+import { formatInputTokenValue } from './formatInputTokenValue';
+
+describe('Format Input Token Value', () => {
+  test('should format input value correctly', () => {
+    expect(formatInputTokenValue("000123.45")).toBe("123.45");
+    expect(formatInputTokenValue("0.123")).toBe("0.123");
+    expect(formatInputTokenValue("abc123.45xyz")).toBe("123.45");
+    expect(formatInputTokenValue("0")).toBe("0");
+    expect(formatInputTokenValue(".45")).toBe("0.45");
+  });
+
+  test('should return "0" for null or undefined input', () => {
+    expect(formatInputTokenValue(null as any)).toBe("0");
+    expect(formatInputTokenValue(undefined as any)).toBe("0");
+  });
+
+  test('should handle numeric input correctly', () => {
+    expect(formatInputTokenValue(0 as any)).toBe("0");
+    expect(formatInputTokenValue(123.45 as any)).toBe("123.45");
+  });
+});

--- a/packages/berajs/src/utils/formatInputTokenValue.ts
+++ b/packages/berajs/src/utils/formatInputTokenValue.ts
@@ -1,7 +1,15 @@
 export const formatInputTokenValue = (inputValue: string) => {
-  if (inputValue === "0") return inputValue;
+  if (inputValue === null || inputValue === undefined || inputValue === "") {
+    return "0";
+  }
+
+  // Convert number to string
+  const inputStr = typeof inputValue === "number" ? Number(inputValue).toString() : inputValue;
+
+  if (inputStr === "0") return inputStr;
+  
   // Remove all non-numeric characters except for the decimal point, and remove leading zeros
-  let filteredValue = inputValue.replace(/^0+/, "").replaceAll(/[^0-9.]/g, "");
+  let filteredValue = inputStr.replace(/^0+/, "").replaceAll(/[^0-9.]/g, "");
 
   // Keep the 0
   if (filteredValue.startsWith(".")) {


### PR DESCRIPTION
### Problem
In this function, it should handle in case of pass param not a string
```diff
export const formatInputTokenValue = (inputValue: string) => {
 // code implement 
+ if (inputValue === null || inputValue === undefined || inputValue === "") {
+    return "0";
+ }
+
+ // Convert number to string
+ const inputStr = typeof inputValue === "number" ? Number(inputValue).toString() : inputValue;

  if (inputStr === "0") return inputStr;

.....

- let filteredValue = inputValue.replace(/^0+/, "").replaceAll(/[^0-9.]/g, "");
+ let filteredValue = inputStr.replace(/^0+/, "").replaceAll(/[^0-9.]/g, "");
}
```
### Test
Add `formatInputTokenValue` unittest.