### PR TITLE
Disable non-fixed Pool Ownership in Pool Create UX

### DIFF
--- a/apps/hub/src/app/pools/components/ownership-input.tsx
+++ b/apps/hub/src/app/pools/components/ownership-input.tsx
@@ -6,6 +6,7 @@ import { cn } from "@bera/ui";
 import { Alert, AlertDescription, AlertTitle } from "@bera/ui/alert";
 import { Card } from "@bera/ui/card";
 import { InputWithLabel } from "@bera/ui/input";
+import { PoolType } from "@berachain-foundation/berancer-sdk";
 
 import BeraTooltip from "~/components/bera-tooltip";
 
@@ -21,8 +22,9 @@ interface OwnershipInputProps {
   onChangeOwnershipType: (type: OwnershipType) => void;
   onOwnerChange: (address: string) => void;
   invalidAddressErrorMessage: string | null;
-  swapFee: number;
   onSwapFeeChange: (fee: number) => void;
+  swapFee: number;
+  poolType: PoolType;
 }
 
 const OwnershipInput: React.FC<OwnershipInputProps> = ({
@@ -33,13 +35,28 @@ const OwnershipInput: React.FC<OwnershipInputProps> = ({
   invalidAddressErrorMessage,
   swapFee,
   onSwapFeeChange,
+  poolType,
 }) => {
+  // NOTE: Balancer support more types of ownership than the ones we are supporting here: Delegated, Fixed and Custom.
+  // ... you can still create Pools with those types of ownership from the contract, but we are not supporting them in the UI.
+
+  let predefinedFees = [0.3, 0.5, 1];
+  if (
+    poolType === PoolType.ComposableStable ||
+    poolType === PoolType.MetaStable
+  ) {
+    predefinedFees = [0.01, 0.05, 0.1];
+  }
   return (
     <section className="flex w-full flex-col gap-4">
       <h3 className="self-start text-3xl font-semibold">Set Swap Fee</h3>
-      <SwapFeeInput initialFee={swapFee} onFeeChange={onSwapFeeChange} />
+      <SwapFeeInput
+        initialFee={swapFee}
+        onFeeChange={onSwapFeeChange}
+        predefinedFees={predefinedFees}
+      />
 
-      <div className="flex items-center gap-1">
+      <div className="flex hidden items-center gap-1">
         <div className="self-start font-semibold">Fee Ownership</div>
         <div className="pt-[-1]">
           <BeraTooltip
@@ -52,7 +69,7 @@ const OwnershipInput: React.FC<OwnershipInputProps> = ({
         </div>
       </div>
 
-      <div className="flex w-full flex-row gap-6">
+      <div className="flex hidden w-full flex-row gap-6">
         <Card
           onClick={() => onChangeOwnershipType(OwnershipType.Governance)}
           className={cn(

--- a/apps/hub/src/app/pools/create/CreatePageContent.tsx
+++ b/apps/hub/src/app/pools/create/CreatePageContent.tsx
@@ -73,7 +73,7 @@ export default function CreatePageContent() {
   const [poolSymbol, setPoolSymbol] = useState<string>("");
   const [amplification, setAmplification] = useState<number>(1); // NOTE: min is 1 max is 5000
   const [ownershipType, setOwnerShipType] = useState<OwnershipType>(
-    OwnershipType.Governance,
+    OwnershipType.Fixed,
   );
   const [invalidAddressErrorMessage, setInvalidAddressErrorMessage] = useState<
     string | null
@@ -130,8 +130,8 @@ export default function CreatePageContent() {
       type === OwnershipType.Governance
         ? balancerDelegatedOwnershipAddress
         : type === OwnershipType.Fixed
-          ? ZERO_ADDRESS
-          : account || zeroAddress,
+        ? ZERO_ADDRESS
+        : account || zeroAddress,
     );
   };
 

--- a/apps/hub/src/app/pools/create/CreatePageContent.tsx
+++ b/apps/hub/src/app/pools/create/CreatePageContent.tsx
@@ -28,6 +28,7 @@ import { InputWithLabel } from "@bera/ui/input";
 import { Separator } from "@bera/ui/separator";
 import {
   PoolType,
+  ZERO_ADDRESS,
   composabableStablePoolV5Abi_V2,
   vaultV2Abi,
   weightedPoolFactoryV4Abi_V2,
@@ -67,7 +68,7 @@ export default function CreatePageContent() {
   ]); // TODO: we should use useMultipleTokenInput here, but it will need weight handling and the ability to add/remove inputs
   const [poolType, setPoolType] = useState<PoolType>(PoolType.ComposableStable);
   const [swapFee, setSwapFee] = useState<number>(0.1);
-  const [owner, setOwner] = useState<string>(balancerDelegatedOwnershipAddress);
+  const [owner, setOwner] = useState<string>(ZERO_ADDRESS);
   const [poolName, setPoolName] = useState<string>("");
   const [poolSymbol, setPoolSymbol] = useState<string>("");
   const [amplification, setAmplification] = useState<number>(1); // NOTE: min is 1 max is 5000
@@ -129,7 +130,7 @@ export default function CreatePageContent() {
       type === OwnershipType.Governance
         ? balancerDelegatedOwnershipAddress
         : type === OwnershipType.Fixed
-          ? "0x0000000000000000000000000000000000000000"
+          ? ZERO_ADDRESS
           : account || zeroAddress,
     );
   };
@@ -397,6 +398,7 @@ export default function CreatePageContent() {
         </section>
 
         <OwnershipInput
+          // NOTE: disabling this means that the default (fixed) ownership type is used always
           ownershipType={ownershipType}
           owner={owner}
           onChangeOwnershipType={handleOwnershipTypeChange}
@@ -404,6 +406,7 @@ export default function CreatePageContent() {
           invalidAddressErrorMessage={invalidAddressErrorMessage}
           swapFee={swapFee}
           onSwapFeeChange={setSwapFee}
+          poolType={poolType}
         />
 
         <section className="flex w-full flex-col gap-4">

--- a/apps/hub/src/app/pools/create/CreatePageContent.tsx
+++ b/apps/hub/src/app/pools/create/CreatePageContent.tsx
@@ -130,8 +130,8 @@ export default function CreatePageContent() {
       type === OwnershipType.Governance
         ? balancerDelegatedOwnershipAddress
         : type === OwnershipType.Fixed
-        ? ZERO_ADDRESS
-        : account || zeroAddress,
+          ? ZERO_ADDRESS
+          : account || zeroAddress,
     );
   };
 

--- a/packages/shared-ui/src/swap-fee.tsx
+++ b/packages/shared-ui/src/swap-fee.tsx
@@ -58,7 +58,7 @@ export function SwapFeeInput({
           className="w-full border-none bg-transparent pr-10 font-semibold"
           aria-label="Swap Fee Input"
         />
-        <div className="flex gap-1 pr-4">
+        <div className="flex gap-2 pr-4">
           {predefinedFees.map((preset) => (
             <button
               type="button"

--- a/packages/shared-ui/src/swap-fee.tsx
+++ b/packages/shared-ui/src/swap-fee.tsx
@@ -19,15 +19,17 @@ export function SwapFeeInput({
   const [isInvalid, setIsInvalid] = useState<boolean>(false);
 
   const handleFeeChange = (value: string) => {
-    const parsedValue = parseFloat(value);
-    setFee(parsedValue);
+    const rawValue = value.replace("%", ""); // NOTE: we need to remove '%' for parsing the actual value
+    const parsedValue = parseFloat(rawValue);
 
-    // Validate the fee range and update the invalid state
-    if (parsedValue >= 0.00001 && parsedValue <= 10) {
-      setIsInvalid(false);
-      onFeeChange(parsedValue);
-    } else {
-      setIsInvalid(true);
+    if (!Number(parsedValue)) {
+      setFee(parsedValue);
+      if (parsedValue >= 0.00001 && parsedValue <= 10) {
+        setIsInvalid(false);
+        onFeeChange(parsedValue);
+      } else {
+        setIsInvalid(true);
+      }
     }
   };
 
@@ -38,38 +40,32 @@ export function SwapFeeInput({
   };
 
   return (
-    <section className="flex w-full flex-col gap-6">
-      <div className="relative flex flex-row gap-6 text-sm">
+    <section
+      className={cn(
+        "flex w-full flex-col gap-6 rounded-md border border-border",
+        isInvalid
+          ? "border-destructive-foreground text-destructive-foreground"
+          : "border-border",
+      )}
+    >
+      <div className="relative flex h-14 flex-row items-center gap-6 text-sm">
         <Input
-          type="number"
+          type="text"
           variant="black"
-          value={fee}
+          value={`${fee}%`}
           onChange={(e) => handleFeeChange(e.target.value)}
           placeholder="Enter swap fee"
-          className={cn(
-            "w-full rounded-md border bg-transparent p-2 pr-10",
-            isInvalid
-              ? "border-destructive-foreground text-destructive-foreground"
-              : "border-border",
-          )}
+          className="w-full border-none bg-transparent pr-10 font-semibold"
           aria-label="Swap Fee Input"
         />
-        <span
-          className={cn(
-            "absolute left-1/2 top-1/2 -translate-y-1/2 transform text-gray-500",
-            isInvalid && "text-destructive-foreground",
-          )}
-        >
-          %
-        </span>
-        <div className="flex gap-2">
+        <div className="flex gap-1 pr-4">
           {predefinedFees.map((preset) => (
             <button
               type="button"
               key={preset}
               onClick={() => handlePredefinedFeeClick(preset)}
               className={cn(
-                "w-20 rounded-md border px-4 py-2",
+                "h-8 w-12 rounded-xs border text-xs font-medium text-muted-foreground",
                 fee === preset ? "border-info-foreground" : "border-border",
               )}
               aria-label="Swap Fee Input"

--- a/packages/shared-ui/src/swap-fee.tsx
+++ b/packages/shared-ui/src/swap-fee.tsx
@@ -5,18 +5,18 @@ import { cn } from "@bera/ui";
 import { Input } from "@bera/ui/input";
 
 interface SwapFeeInputProps {
+  onFeeChange: (fee: number) => void;
   initialFee?: number;
-  onFeeChange?: (fee: number) => void;
+  predefinedFees?: number[];
 }
 
 export function SwapFeeInput({
   initialFee = 0,
   onFeeChange,
+  predefinedFees = [0.1, 0.2, 0.3],
 }: SwapFeeInputProps) {
   const [fee, setFee] = useState<number>(initialFee);
   const [isInvalid, setIsInvalid] = useState<boolean>(false);
-
-  const predefinedFees = [0.1, 0.2, 0.3];
 
   const handleFeeChange = (value: string) => {
     const parsedValue = parseFloat(value);
@@ -25,7 +25,7 @@ export function SwapFeeInput({
     // Validate the fee range and update the invalid state
     if (parsedValue >= 0.00001 && parsedValue <= 10) {
       setIsInvalid(false);
-      onFeeChange?.(parsedValue); // Pass valid fee to parent, if callback provided
+      onFeeChange(parsedValue);
     } else {
       setIsInvalid(true);
     }
@@ -34,12 +34,12 @@ export function SwapFeeInput({
   const handlePredefinedFeeClick = (value: number) => {
     setFee(value);
     setIsInvalid(false);
-    onFeeChange?.(value);
+    onFeeChange(value);
   };
 
   return (
     <section className="flex w-full flex-col gap-6">
-      <div className="relative flex flex-row gap-6">
+      <div className="relative flex flex-row gap-6 text-sm">
         <Input
           type="number"
           variant="black"
@@ -69,7 +69,7 @@ export function SwapFeeInput({
               key={preset}
               onClick={() => handlePredefinedFeeClick(preset)}
               className={cn(
-                "rounded-md border px-4 py-2",
+                "w-20 rounded-md border px-4 py-2",
                 fee === preset ? "border-info-foreground" : "border-border",
               )}
               aria-label="Swap Fee Input"


### PR DESCRIPTION
This disables delegated and custom ownership options in the pool create UX (which are still accessible contract-side), and differentiate fee presets between weighted and stable pools. 

This also has a seperate commit which updates the look and feel of swap fee

![image](https://github.com/user-attachments/assets/dfe3d09a-a8dd-40d3-855f-23e01eaa71a8)


![image](https://github.com/user-attachments/assets/290ac5d7-f999-43d7-bd2a-c08140b3f25d)
(preview still shows pool ownership)