### PR TITLE
Decouple weight input from normalization logic

### DIFF
--- a/apps/hub/src/app/pools/components/create-pool-input.tsx
+++ b/apps/hub/src/app/pools/components/create-pool-input.tsx
@@ -56,7 +56,12 @@ export default function CreatePoolInput({
     // This lets the user type in numbers with a period character without sending invalid bigInt to usePoolWeights
     const inputValue = e.target.value;
     const numericCharacterCount = inputValue.replace(/[^0-9]/g, "").length;
+
     if (numericCharacterCount > 18) {
+      return;
+    }
+
+    if ((inputValue.match(/\./g) || []).length > 1) {
       return;
     }
 


### PR DESCRIPTION
This decouples the weights a user types from those that we send to normalize so that user can type decimals.

i.e. you can now directly type a weight like this:
![image](https://github.com/user-attachments/assets/832f0bcc-fd20-4f53-91ce-f6e4cf15ed1b)
