### PR TITLE
Fix/balancer/swap simulation

### DIFF
--- a/apps/hub/src/components/swap-card.tsx
+++ b/apps/hub/src/components/swap-card.tsx
@@ -4,10 +4,12 @@ import React, { useEffect, useMemo, useState } from "react";
 import dynamic from "next/dynamic";
 import {
   BGT_ABI,
+  IContractWrite,
   // Vault
   // @ts-ignore - ignore Token typing import error
   Token,
   TransactionActionType,
+  balancerVaultAbi,
   useBeraJs,
   useBgtUnstakedBalance,
   usePollWalletBalances,
@@ -23,6 +25,7 @@ import {
 } from "@bera/config";
 import {
   ActionButton,
+  AddTokenDialog,
   ApproveButton,
   BREAKPOINTS,
   TokenInput,
@@ -32,14 +35,13 @@ import {
   useSlippage,
   useTxn,
 } from "@bera/shared-ui";
-import { AddTokenDialog } from "@bera/shared-ui";
 import { cn } from "@bera/ui";
 import { Alert, AlertDescription, AlertTitle } from "@bera/ui/alert";
 import { Button } from "@bera/ui/button";
 import { Card } from "@bera/ui/card";
 import { Icons } from "@bera/ui/icons";
 import { SwapBuildOutputExactIn } from "@berachain-foundation/berancer-sdk";
-import { formatUnits, isAddress, parseUnits } from "viem";
+import { decodeFunctionData, formatUnits, isAddress, parseUnits } from "viem";
 
 import { WRAP_TYPE, useSwap } from "~/hooks/useSwap";
 import { SwapCardHeader } from "./swap-card-header";
@@ -382,12 +384,21 @@ export function SwapCard({
             setOpen={setOpenPreview}
             write={() => {
               const calldata = swapInfo.buildCall(slippage ?? 0);
-              // @ts-expect-error export args from buildCall so we can simulate
+              // NOTE: the decode and write here is a kludge to avoid re-writing the way the balancer SDK builds txs so we can simulate
+              const decodedData = decodeFunctionData({
+                abi: balancerVaultAbi,
+                data: calldata.callData,
+              });
               write({
                 address: calldata.to,
-                data: calldata.callData,
+                abi: balancerVaultAbi,
+                functionName: decodedData.functionName,
+                params: decodedData.args,
                 value: calldata.value,
-              });
+              } as IContractWrite<
+                typeof balancerVaultAbi,
+                typeof decodedData.functionName
+              >);
             }}
             isLoading={isLoading}
             minAmountOut={minAmountOut ?? "n/a"}

--- a/packages/berajs/src/abi/bex/balancerVaultAbi.ts
+++ b/packages/berajs/src/abi/bex/balancerVaultAbi.ts
@@ -754,4 +754,4 @@ export const balancerVaultAbi = [
     type: "function",
   },
   { stateMutability: "payable", type: "receive" },
-];
+] as const;


### PR DESCRIPTION
This makes it so that we run simulation for swap like in pool creation/add liquidity.

To avoid changing the way the b-sdk construct callData for swap paths, I've opted to decode the callData in swap-card, if we prefer the other route that's valid but it'll take more time to ensure we dont' break other things inside b-sdk that rely on this flow. 