### PR TITLE
 Fixed a typo/Changes in documentation files

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 #### **Did you find a bug?**
 
 * **Do not open up a GitHub issue if the bug is a security vulnerability
-  in Monobera**, and instead reach out our mods on our Discord server.
+  in Monobera**, and instead reach out to our mods on our Discord server.
 
 * **Ensure the bug was not already reported** by searching on GitHub under [Issues](https://github.com/berachain/monobera/issues).
 
@@ -17,7 +17,7 @@
 
 #### **Did you fix whitespace, format code, or make a purely cosmetic patch?**
 
-Changes that are cosmetic in nature and do not add anything substantial to the stability, functionality, or testability of this repo will generally not be accepted (we totally agree with the reasons outline in this [Ruby on Rails pull request](https://github.com/rails/rails/pull/13771#issuecomment-32746700)).
+Changes that are cosmetic in nature and do not add anything substantial to the stability, functionality, or testability of this repo will generally not be accepted (we totally agree with the reasons outlined in this [Ruby on Rails pull request](https://github.com/rails/rails/pull/13771#issuecomment-32746700)).
 
 <!-- #### **Do you intend to add a new feature or change an existing one?**
 

--- a/apps/berajs-docs/docs/pages/actions/dex/getRoute.mdx
+++ b/apps/berajs-docs/docs/pages/actions/dex/getRoute.mdx
@@ -58,8 +58,8 @@ const route = await getRoute({
 | ----------------------- | :-------------------------------- | :------------------------------------------------------------ | :------: |
 | `args.tokenIn`          | `string`                          | The address of the token to be given in the swap              |  `true`  |
 | `args.tokenOut`         | `string`                          | The address of the token to be received in the swap           |  `true`  |
-| `args.tokenInDecimals`  | `number`                          | The amount of decimals to divide the tokenOut amount          |  `true`  |
-| `args.tokenOutDecimals` | `number`                          | The amount of decimals to divide the tokenOut amount          |  `true`  |
+| `args.tokenInDecimals`  | `number`                          | The amount of decimals for the input token                    |  `true`  |
+| `args.tokenOutDecimals` | `number`                          | The amount of decimals for the output token                   |  `true`  |
 | `args.amount`           | `string`                          | The amount of the tokenIn to be given in the swap             |  `true`  |
 | `config`                | [`BeraConfig`](/types/BeraConfig) | BeraConfig object containing addresses for relevant resources |  `true`  |
 

--- a/apps/berajs-docs/docs/pages/actions/dex/getSwap.mdx
+++ b/apps/berajs-docs/docs/pages/actions/dex/getSwap.mdx
@@ -63,7 +63,7 @@ const swap = await getSwap({
 | `args.tokenOutDecimals` | `number`                          | The amount of decimals for the output token                   |  `true`  |
 | `args.amount`           | `string`                          | The amount of the tokenIn to be given in the swap             |  `true`  |
 | `config`                | [`BeraConfig`](/types/BeraConfig) | BeraConfig object containing addresses for relevant resources |  `true`  |
-| publicClient            | PublicClient                      | The public client used to interact with the blockchain        |  `true`  |
+| `publicClient`          | `PublicClient`                    | The public client used to interact with the blockchain        |  `true`  |
 
 
 ## Returns [`Promise<SwapInfoV3 | undefined>`](/types/SwapInfoV3/)

--- a/apps/berajs-docs/docs/pages/actions/dex/getSwap.mdx
+++ b/apps/berajs-docs/docs/pages/actions/dex/getSwap.mdx
@@ -59,10 +59,12 @@ const swap = await getSwap({
 | ----------------------- | :-------------------------------- | :------------------------------------------------------------ | :------: |
 | `args.tokenIn`          | `string`                          | The address of the token to be given in the swap              |  `true`  |
 | `args.tokenOut`         | `string`                          | The address of the token to be received in the swap           |  `true`  |
-| `args.tokenInDecimals`  | `number`                          | The amount of decimals to divide the tokenOut amount          |  `true`  |
-| `args.tokenOutDecimals` | `number`                          | The amount of decimals to divide the tokenOut amount          |  `true`  |
+| `args.tokenInDecimals`  | `number`                          | The amount of decimals for the input token                    |  `true`  |
+| `args.tokenOutDecimals` | `number`                          | The amount of decimals for the output token                   |  `true`  |
 | `args.amount`           | `string`                          | The amount of the tokenIn to be given in the swap             |  `true`  |
 | `config`                | [`BeraConfig`](/types/BeraConfig) | BeraConfig object containing addresses for relevant resources |  `true`  |
+| publicClient            | PublicClient                      | The public client used to interact with the blockchain        |  `true`  |
+
 
 ## Returns [`Promise<SwapInfoV3 | undefined>`](/types/SwapInfoV3/)
 

--- a/apps/berajs-docs/docs/pages/actions/dex/getWithdrawLiquidityPayload.mdx
+++ b/apps/berajs-docs/docs/pages/actions/dex/getWithdrawLiquidityPayload.mdx
@@ -41,8 +41,8 @@ const withdrawLiqPayload = await getWithdrawLiquidityPayload({
 | --------------------- | :-------------------------- | :---------------------------------------------------------- | :------: |
 | `args.slippage`       | `number`                    | Slippage tolerance in percentage between 0.1 to 100         |  `true`  |
 | `args.poolPrice`      | `number`                    | Pool price                                                  |  `true`  |
-| `args.baseToken`      | [`Token`](<(/types/Token)>) | Token object representing the pool's base token             |  `true`  |
-| `args.quoteToken`     | [`Token`](<(/types/Token)>) | Token object representing the pool's quote token            |  `true`  |
+| `args.baseToken`      | [`Token`](/types/Token)     | Token object representing the pool's base token             |  `true`  |
+| `args.quoteToken`     | [`Token`](/types/Token)     | Token object representing the pool's quote token            |  `true`  |
 | `args.poolIdx`        | `number`                    | Pool on-chain id                                            |  `true`  |
 | `args.percentRemoval` | `number`                    | Percent of user's stake to be withdrawn from pool           |  `true`  |
 | `args.seeds`          | `string`                    | Seeds                                                       |  `true`  |


### PR DESCRIPTION
1. ** Fixed a typo ** in the documentation for the parameters `args.tokenindecimals` and` args.tokenutdecimals
 - The description of both parameters initially indicates "the number of decimal affairs in order to divide the amount of token." This was fixed:
 - `Args.tokenindecimals`: *" The number of decimal cases for input token " *
 - `Args.tokenutdecimals`: *" The number of decimal cases for the output token " *

2. ** Added the missing parameter `publicClient` ** in the documentation for` getswap`:
 - The `PublicClient 'parameter was mentioned in the example of use, but was not included in the parameter table. Now it has been added with the description:
 - `publicClient`: *" The public client used to interact with the blockchain " *

#### ** Changes in documentation files: **

1.
 - A fixed description of the parameters `args.tokenindecimals` and` args.tokenutdecimals` to accurately reflect their goal.
 - `Args.tokenindecimals`: *" The number of decimal cases for input token " *
 - `Args.tokenutdecimals`: *" The number of decimal cases for the output token " *

2. ** Applications/birajs-docs/docs/pages/Action/DEX/GETSWAP.MDX: **
 - Added the `PublicClient` parameter in the documentation.
 - I updated the description for `args.tokenindecimals` and` args.tokenutdecimals` to be more accurate.