### PR TITLE
docs: cleanup document

### DIFF
--- a/apps/berajs-docs/docs/pages/actions/getting-started.mdx
+++ b/apps/berajs-docs/docs/pages/actions/getting-started.mdx
@@ -34,7 +34,7 @@ You will need to pass in `publicClient` to most actions, you can initialize a vi
 import { createPublicClient, http } from "viem";
 import { berachain } from "viem/chains";
 
-// first, intialize a public client with berachain
+// first, initialize a public client with berachain
 const publicClient = createPublicClient({
   chain: berachain, // viem chains directory: https://github.com/wevm/viem/blob/main/src/chains/index.ts
   transport: http(),
@@ -56,13 +56,13 @@ import { createPublicClient, } from 'viem'
 import { berachain } from 'viem/chains'
 import { getSwap, type BeraConfig } from '@bera/berajs'
 
-// first, intialize a public client with berachain
+// first, initialize a public client with berachain
 const publicClient = createPublicClient({
   chain: berachain, // viem chains directory: https://github.com/wevm/viem/blob/main/src/chains/index.ts
   transport: http()
 })
 
-// intialize a beraconfig (optional)
+// initialize a beraconfig (optional)
 const beraConfig: BeraConfig = {
     endpoints: {
         dexRouter: 'https://'

--- a/apps/berajs-docs/docs/pages/actions/honey/getCollateralRates.mdx
+++ b/apps/berajs-docs/docs/pages/actions/honey/getCollateralRates.mdx
@@ -37,7 +37,7 @@ import { getCollateralRates } from "@bera/berajs/actions";
 import { createPublicClient, http } from "viem";
 import { berachain } from "viem/chains";
 
-// first, intialize a public client with berachain
+// first, initialize a public client with berachain
 const publicClient = createPublicClient({
   chain: berachain, // viem chains directory: https://github.com/wevm/viem/blob/main/src/chains/index.ts
   transport: http(),

--- a/apps/berajs-docs/docs/pages/actions/honey/getHoneyPreview.mdx
+++ b/apps/berajs-docs/docs/pages/actions/honey/getHoneyPreview.mdx
@@ -36,7 +36,7 @@ import { getHoneyPreview, HoneyPreviewMethod } from "@bera/berajs/actions";
 import { createPublicClient, http } from "viem";
 import { berachain } from "viem/chains";
 
-// first, intialize a public client with berachain
+// first, initialize a public client with berachain
 const publicClient = createPublicClient({
   chain: berachain, // viem chains directory: https://github.com/wevm/viem/blob/main/src/chains/index.ts
   transport: http(),

--- a/apps/berajs-docs/docs/pages/actions/lend/getLendWithdrawPayload.mdx
+++ b/apps/berajs-docs/docs/pages/actions/lend/getLendWithdrawPayload.mdx
@@ -1,6 +1,6 @@
 # getLendWithdrawPayload
 
-Action for creating the withdraw payload for transaction in lend.
+Action for creating the withdraw payload for a transaction in lend.
 
 ## Initialization
 

--- a/apps/berajs-docs/docs/pages/actions/utils/getAllowance.mdx
+++ b/apps/berajs-docs/docs/pages/actions/utils/getAllowance.mdx
@@ -19,7 +19,7 @@ import { getAllowance } from "@bera/berajs/actions";
 import { createPublicClient, http } from "viem";
 import { berachain } from "viem/chains";
 
-// first, intialize a public client with berachain
+// first, initialize a public client with berachain
 const publicClient = createPublicClient({
   chain: berachain, // viem chains directory: https://github.com/wevm/viem/blob/main/src/chains/index.ts
   transport: http(),

--- a/apps/berajs-docs/docs/pages/actions/utils/getAllowances.mdx
+++ b/apps/berajs-docs/docs/pages/actions/utils/getAllowances.mdx
@@ -19,7 +19,7 @@ import { getAllowances } from "@bera/berajs/actions";
 import { createPublicClient, http } from "viem";
 import { berachain } from "viem/chains";
 
-// first, intialize a public client with berachain
+// first, initialize a public client with berachain
 const publicClient = createPublicClient({
   chain: berachain, // viem chains directory: https://github.com/wevm/viem/blob/main/src/chains/index.ts
   transport: http(),

--- a/apps/berajs-docs/docs/pages/actions/utils/getTokenInformation.mdx
+++ b/apps/berajs-docs/docs/pages/actions/utils/getTokenInformation.mdx
@@ -22,7 +22,7 @@ import { getTokenInformation } from "@bera/berajs/actions";
 import { createPublicClient, http } from "viem";
 import { berachain } from "viem/chains";
 
-// first, intialize a public client with berachain
+// first, initialize a public client with berachain
 const publicClient = createPublicClient({
   chain: berachain, // viem chains directory: https://github.com/wevm/viem/blob/main/src/chains/index.ts
   transport: http(),

--- a/apps/berajs-docs/docs/pages/actions/utils/getWalletBalances.mdx
+++ b/apps/berajs-docs/docs/pages/actions/utils/getWalletBalances.mdx
@@ -34,7 +34,7 @@ import { getWalletBalances } from "@bera/berajs/actions";
 import { createPublicClient, http } from "viem";
 import { berachain } from "viem/chains";
 
-// first, intialize a public client with berachain
+// first, initialize a public client with berachain
 const publicClient = createPublicClient({
   chain: berachain, // viem chains directory: https://github.com/wevm/viem/blob/main/src/chains/index.ts
   transport: http(),

--- a/apps/berajs-docs/docs/pages/react/dex/usePoolUserPosition.mdx
+++ b/apps/berajs-docs/docs/pages/react/dex/usePoolUserPosition.mdx
@@ -41,7 +41,7 @@ function usePoolUserPosition(
 
 | Name   | type     | Description                                               | Required |
 | ------ | :------- | :-------------------------------------------------------- | :------: |
-| `pool` | `PoolV2` | pool of which to fetch the connect wallet user's position |  `true`  |
+| `pool` | `PoolV2` | pool of which to fetch the connected wallet user's position |  `true`  |
 
 #### options: `DefaultHookOptions`
 

--- a/apps/berajs-docs/docs/pages/react/lend/usePollUserAccountData.mdx
+++ b/apps/berajs-docs/docs/pages/react/lend/usePollUserAccountData.mdx
@@ -1,6 +1,6 @@
 # usePollUserAccountData
 
-React SWR hook to fetching the user account.
+React SWR hook for fetching the user account.
 
 ## Initialization
 
@@ -16,7 +16,7 @@ import { usePollUserAccountData } from "@bera/berajs";
 
 :::code
 
-```ts [exmaple.ts]
+```ts [example.ts]
 const { data: userData } = usePollUserAccountData();
 ```
 

--- a/apps/berajs-docs/docs/pages/react/perps/useIsDelegated.mdx
+++ b/apps/berajs-docs/docs/pages/react/perps/useIsDelegated.mdx
@@ -16,7 +16,7 @@ import { useIsDelegated } from "@bera/berajs";
 
 :::code
 
-```ts [exmaple.ts]
+```ts [example.ts]
 const { data: isDelegated, refresh } = useIsDelegated();
 ```
 

--- a/apps/berajs-docs/docs/pages/react/utils/usePollAllowance.mdx
+++ b/apps/berajs-docs/docs/pages/react/utils/usePollAllowance.mdx
@@ -1,6 +1,6 @@
 # usePollAllowance
 
-React hook for poll the allowance of a given token
+React hook for polling the allowance of a given token
 
 ## Import
 


### PR DESCRIPTION
I found various typos and grammatical errors in the documentation, including an incorrect file name (exmaple.ts).

I think it's important to correct these typos and grammatical errors because in ‘public’ documentation, even a single spelling error can be interpreted differently from the original meaning.

Hope this fix helps.
