### PR TITLE
Set a transaction deadline for swaps

### DIFF
--- a/apps/hub/src/b-sdk/usePollBalancerSwap.ts
+++ b/apps/hub/src/b-sdk/usePollBalancerSwap.ts
@@ -19,6 +19,7 @@ import useSWR from "swr";
 import { formatUnits } from "viem";
 import { usePublicClient } from "wagmi";
 
+import { DEFAULT_DEADLINE } from "~/utils/constants";
 import { balancerApi, nativeToken } from "./b-sdk";
 
 type IUsePollSwapsArgs = SwapRequest;
@@ -108,7 +109,7 @@ export const usePollBalancerSwap = (
 
   const publicClient = usePublicClient();
   const { account, config: beraConfig } = useBeraJs();
-  const defaultDeadlineIn = 30; // seconds
+  const defaultDeadlineIn = DEFAULT_DEADLINE; // seconds
 
   const config = options?.beraConfigOverride ?? beraConfig;
   const QUERY_KEY =

--- a/apps/hub/src/components/swap-card.tsx
+++ b/apps/hub/src/components/swap-card.tsx
@@ -32,7 +32,6 @@ import {
   TooltipCustom,
   useAnalytics,
   useBreakpoint,
-  useDeadline,
   useSlippage,
   useTxn,
 } from "@bera/shared-ui";
@@ -93,7 +92,6 @@ export function SwapCard({
   className,
 }: ISwapCard) {
   const slippage = useSlippage();
-  const { deadline } = useDeadline();
 
   const {
     setSelectedFrom,
@@ -392,7 +390,7 @@ export function SwapCard({
             open={openPreview}
             setOpen={setOpenPreview}
             write={() => {
-              const calldata = swapInfo.buildCall(slippage ?? 0, deadline);
+              const calldata = swapInfo.buildCall(slippage ?? 0);
               // NOTE: the decode and write here is a kludge to avoid re-writing the way the balancer SDK builds txs so we can simulate
               const decodedData = decodeFunctionData({
                 abi: balancerVaultAbi,

--- a/apps/hub/src/components/swap-card.tsx
+++ b/apps/hub/src/components/swap-card.tsx
@@ -32,6 +32,7 @@ import {
   TooltipCustom,
   useAnalytics,
   useBreakpoint,
+  useDeadline,
   useSlippage,
   useTxn,
 } from "@bera/shared-ui";
@@ -92,6 +93,7 @@ export function SwapCard({
   className,
 }: ISwapCard) {
   const slippage = useSlippage();
+  const { deadline } = useDeadline();
 
   const {
     setSelectedFrom,
@@ -390,7 +392,7 @@ export function SwapCard({
             open={openPreview}
             setOpen={setOpenPreview}
             write={() => {
-              const calldata = swapInfo.buildCall(slippage ?? 0);
+              const calldata = swapInfo.buildCall(slippage ?? 0, deadline);
               // NOTE: the decode and write here is a kludge to avoid re-writing the way the balancer SDK builds txs so we can simulate
               const decodedData = decodeFunctionData({
                 abi: balancerVaultAbi,

--- a/apps/hub/src/components/swap-settings.tsx
+++ b/apps/hub/src/components/swap-settings.tsx
@@ -185,7 +185,7 @@ export default function SwapSettings({
                     deadlineType === SELECTION.AUTO && "opacity-50",
                   )}
                 >
-                  min
+                  sec
                 </p>
               }
               onChange={(e: React.ChangeEvent<HTMLInputElement>) =>

--- a/apps/hub/src/components/swap-settings.tsx
+++ b/apps/hub/src/components/swap-settings.tsx
@@ -12,6 +12,7 @@ import {
   DEFAULT_SLIPPAGE,
   DEFAULT_SOUND_ENABLED,
   LOCAL_STORAGE_KEYS,
+  MAX_INPUT_DEADLINE,
 } from "~/utils/constants";
 
 export enum SELECTION {
@@ -165,15 +166,20 @@ export default function SwapSettings({
             <Input
               type="number"
               step="any"
-              min={0.1}
-              max={100}
-              className="h-[40px] pl-1 pr-9 text-right"
+              className={cn(
+                "h-[40px] pl-1 pr-9",
+                deadlineType === SELECTION.INFINITY
+                  ? "text-center"
+                  : "text-right",
+              )}
               disabled={deadlineType !== SELECTION.CUSTOM}
-              placeholder="1"
+              placeholder={deadlineType === SELECTION.INFINITY ? "∞" : ""}
               value={
                 deadlineType === SELECTION.AUTO
                   ? DEFAULT_DEADLINE
-                  : deadlineValue
+                  : deadlineType === SELECTION.INFINITY
+                    ? ""
+                    : deadlineValue
               }
               onKeyDown={(e: KeyboardEvent<HTMLInputElement>) =>
                 e.key === "-" && e.preventDefault()
@@ -188,9 +194,12 @@ export default function SwapSettings({
                   sec
                 </p>
               }
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                setDeadlineValue(Number(e.target.value))
-              }
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                let value = Number(e.target.value);
+                if (value < 0.1) value = 0.1;
+                if (value > MAX_INPUT_DEADLINE) value = MAX_INPUT_DEADLINE;
+                setDeadlineValue(value);
+              }}
             />
           </div>
           {deadlineType === SELECTION.INFINITY && (

--- a/apps/hub/src/utils/constants.ts
+++ b/apps/hub/src/utils/constants.ts
@@ -12,6 +12,7 @@ export enum LOCAL_STORAGE_KEYS {
 export const DEFAULT_DEADLINE = 30; // seconds
 export const DEFAULT_SLIPPAGE = 1; // 0.3%
 export const DEFAULT_SOUND_ENABLED = true; // 1 if true, 0 if false
+export const MAX_INPUT_DEADLINE = 100000; // seconds
 
 export enum TRANSACTION_TYPES {
   LEGACY = "legacy",

--- a/apps/hub/src/utils/constants.ts
+++ b/apps/hub/src/utils/constants.ts
@@ -9,7 +9,7 @@ export enum LOCAL_STORAGE_KEYS {
   DEADLINE_VALUE = "DEADLINE_VALUE",
 }
 
-export const DEFAULT_DEADLINE = 30; // minutes
+export const DEFAULT_DEADLINE = 30; // seconds
 export const DEFAULT_SLIPPAGE = 1; // 0.3%
 export const DEFAULT_SOUND_ENABLED = true; // 1 if true, 0 if false
 

--- a/packages/shared-ui/src/hooks/useDeadline.ts
+++ b/packages/shared-ui/src/hooks/useDeadline.ts
@@ -23,7 +23,7 @@ export const useDeadline = () => {
       return deadline;
     }
     if (deadlineMode === TRANSACTION_MODE.INFINITY) {
-      return 100000;
+      return 100000; // seconds
     }
   }, [deadlineMode, deadline]);
 

--- a/packages/shared-ui/src/hooks/useDeadline.ts
+++ b/packages/shared-ui/src/hooks/useDeadline.ts
@@ -13,7 +13,7 @@ export const useDeadline = () => {
     DEADLINE_TYPE,
     TRANSACTION_MODE.AUTO,
   );
-  const [deadline] = useLocalStorage<number>(DEADLINE_VALUE, DEFAULT_DEADLINE);
+  const [deadline] = useLocalStorage<number>(DEADLINE_VALUE, DEFAULT_DEADLINE); // seconds
 
   const computedDeadline = useMemo(() => {
     if (deadlineMode === TRANSACTION_MODE.AUTO) {
@@ -23,7 +23,7 @@ export const useDeadline = () => {
       return deadline;
     }
     if (deadlineMode === TRANSACTION_MODE.INFINITY) {
-      return 100000; // seconds
+      return Number.MAX_SAFE_INTEGER;
     }
   }, [deadlineMode, deadline]);
 

--- a/packages/shared-ui/src/hooks/useDeadline.ts
+++ b/packages/shared-ui/src/hooks/useDeadline.ts
@@ -15,7 +15,7 @@ export const useDeadline = () => {
   );
   const [deadline] = useLocalStorage<number>(DEADLINE_VALUE, DEFAULT_DEADLINE);
 
-  return useMemo(() => {
+  const computedDeadline = useMemo(() => {
     if (deadlineMode === TRANSACTION_MODE.AUTO) {
       return DEFAULT_DEADLINE;
     }
@@ -26,4 +26,6 @@ export const useDeadline = () => {
       return 100000;
     }
   }, [deadlineMode, deadline]);
+
+  return { deadlineMode, deadline: computedDeadline };
 };


### PR DESCRIPTION
Now the tx deadline is respected for swaps per the settings 
<img width="380" alt="image" src="https://github.com/user-attachments/assets/cb182c02-3dc7-4602-8113-40fa9ec26a1f">


NOTE: you can set this deadline very very small to test this, I think really the input should be limited in terms of how small a number you can type, but that is a separate [issue](https://berachain-fe.atlassian.net/browse/BFE-363). 