### PR TITLE
Fix Hyphenation in PoolDayDataV2 Descriptions 

### DIFF
--- a/apps/berajs-docs/docs/pages/types/PoolDayDataV2.mdx
+++ b/apps/berajs-docs/docs/pages/types/PoolDayDataV2.mdx
@@ -10,7 +10,7 @@ import { type PoolDayDataV2 } from "@bera/graphql";
 
 | Name               | type     | Description                                                                                 | Optional |
 | ------------------ | :------- | :------------------------------------------------------------------------------------------ | :------: |
-| `day`              | `number` | UNIX timestamp of day for this 24 hour data snapshot                                        | `false`  |
+| `day`              | `number` | UNIX timestamp of day for this 24-hour data snapshot                                        | `false`  |
 | `volume24HInHoney` | `number` | Estimated USD value of the trade volume in the pool over the past 24 hours                  | `false`  |
-| `tvlInHoney`       | `number` | Estimated USD value of the total value locked in the pool at the end of this 24 hour period | `false`  |
+| `tvlInHoney`       | `number` | Estimated USD value of the total value locked in the pool at the end of this 24-hour period | `false`  |
 | `fees24HInHoney`   | `number` | Estimated USD value of the fees paid in pool transactions over the past 24 hours            | `false`  |


### PR DESCRIPTION
This PR addresses grammatical inconsistencies in the `PoolDayDataV2.mdx` file by correcting the use of "24 hour" to the proper "24-hour" format when used as a modifier.  

### Changes:  
- Updated "24 hour data snapshot" to "24-hour data snapshot".  
- Updated "24 hour period" to "24-hour period".  

### Key Areas to Review:  
- Ensure grammatical corrections are accurate and consistent.  
