### PR TITLE
Sanitize & clamp Swap-Settings inputs properly

### DIFF
--- a/apps/hub/src/components/swap-settings.tsx
+++ b/apps/hub/src/components/swap-settings.tsx
@@ -86,6 +86,7 @@ export default function SwapSettings({
             step="any"
             min={MIN_SLIPPAGE}
             max={MAX_SLIPPAGE}
+            className="text-right"
             disabled={slippageToleranceType !== SELECTION.CUSTOM}
             value={
               slippageToleranceType === SELECTION.AUTO
@@ -165,7 +166,7 @@ export default function SwapSettings({
             <Input
               type="number"
               step="any"
-              className="h-[40px] pl-1 pr-9 text-right"
+              className="h-[40px] text-right"
               min={MIN_INPUT_DEADLINE}
               max={MAX_INPUT_DEADLINE}
               disabled={deadlineType !== SELECTION.CUSTOM}

--- a/apps/hub/src/components/swap-settings.tsx
+++ b/apps/hub/src/components/swap-settings.tsx
@@ -11,10 +11,10 @@ import {
   DEFAULT_DEADLINE,
   DEFAULT_SLIPPAGE,
   LOCAL_STORAGE_KEYS,
-  MAX_INPUT_DEADLINE,
-  MAX_SLIPPAGE,
-  MIN_INPUT_DEADLINE,
-  MIN_SLIPPAGE,
+  MAX_CUSTOM_DEADLINE,
+  MAX_CUSTOM_SLIPPAGE,
+  MIN_CUSTOM_DEADLINE,
+  MIN_CUSTOM_SLIPPAGE,
 } from "~/utils/constants";
 
 export enum SELECTION {
@@ -84,8 +84,8 @@ export default function SwapSettings({
           <Input
             type="number"
             step="any"
-            min={MIN_SLIPPAGE}
-            max={MAX_SLIPPAGE}
+            min={MIN_CUSTOM_SLIPPAGE}
+            max={MAX_CUSTOM_SLIPPAGE}
             className="text-right"
             disabled={slippageToleranceType !== SELECTION.CUSTOM}
             value={
@@ -112,8 +112,10 @@ export default function SwapSettings({
             }
             onChange={(e: React.FocusEvent<HTMLInputElement>) => {
               const value = parseFloat(e.target.value);
-              if (value > MAX_SLIPPAGE) setSlippageToleranceValue(MAX_SLIPPAGE);
-              if (value < MIN_SLIPPAGE) setSlippageToleranceValue(MIN_SLIPPAGE);
+              if (value > MAX_CUSTOM_SLIPPAGE)
+                setSlippageToleranceValue(MAX_CUSTOM_SLIPPAGE);
+              if (value < MIN_CUSTOM_SLIPPAGE)
+                setSlippageToleranceValue(MIN_CUSTOM_SLIPPAGE);
               setSlippageToleranceValue(value);
             }}
           />
@@ -167,8 +169,8 @@ export default function SwapSettings({
               type="number"
               step="any"
               className="h-[40px] text-right"
-              min={MIN_INPUT_DEADLINE}
-              max={MAX_INPUT_DEADLINE}
+              min={MIN_CUSTOM_DEADLINE}
+              max={MAX_CUSTOM_DEADLINE}
               disabled={deadlineType !== SELECTION.CUSTOM}
               placeholder={deadlineType === SELECTION.INFINITY ? "∞" : ""}
               value={
@@ -195,8 +197,8 @@ export default function SwapSettings({
               }
               onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                 let value = Number(e.target.value);
-                if (value < MIN_INPUT_DEADLINE) value = MIN_INPUT_DEADLINE;
-                if (value > MAX_INPUT_DEADLINE) value = MAX_INPUT_DEADLINE;
+                if (value < MIN_CUSTOM_DEADLINE) value = MIN_CUSTOM_DEADLINE;
+                if (value > MAX_CUSTOM_DEADLINE) value = MAX_CUSTOM_DEADLINE;
                 setDeadlineValue(value);
               }}
             />

--- a/apps/hub/src/utils/constants.ts
+++ b/apps/hub/src/utils/constants.ts
@@ -10,14 +10,43 @@ export enum LOCAL_STORAGE_KEYS {
   CLAIM_REWARDS_RECIPIENT = "CLAIM_REWARDS_RECIPIENT",
 }
 
-// FIXME: this and settings.tsx are defining similar things (mostly for the swap-settings & settings inputs)
-export const DEFAULT_DEADLINE = 30; // seconds
-export const DEFAULT_SLIPPAGE = 1; // 1%
-export const MAX_INPUT_DEADLINE = 100000; // seconds
-export const MIN_INPUT_DEADLINE = 1; // seconds
-export const MIN_SLIPPAGE = 0.1; // 0.1%
-export const MAX_SLIPPAGE = 100; // 100%
-export const DEFAULT_SOUND_ENABLED = true; // 1 if true, 0 if false
+// TODO (BFE-400): this and settings.tsx are defining similar things (mostly for the swap-settings & settings inputs)
+
+/**
+ * Default transaction deadline in seconds.
+ * @type {number}
+ */
+export const DEFAULT_DEADLINE = 30;
+
+/**
+ * Default slippage tolerance percentage.
+ * @type {number}
+ */
+export const DEFAULT_SLIPPAGE = 1;
+
+/**
+ * Maximum allowed input for a custom deadline in seconds.
+ * @type {number}
+ */
+export const MAX_CUSTOM_DEADLINE = 100000;
+
+/**
+ * Minimum allowed input for a custom deadline in seconds.
+ * @type {number}
+ */
+export const MIN_CUSTOM_DEADLINE = 1;
+
+/**
+ * Minimum allowed input for a custom slippage tolerance percentage.
+ * @type {number}
+ */
+export const MIN_CUSTOM_SLIPPAGE = 0.1;
+
+/**
+ * Maximum allowed input for a custom slippage tolerance percentage.
+ * @type {number}
+ */
+export const MAX_CUSTOM_SLIPPAGE = 100;
 
 export enum TRANSACTION_TYPES {
   LEGACY = "legacy",

--- a/apps/hub/src/utils/constants.ts
+++ b/apps/hub/src/utils/constants.ts
@@ -9,10 +9,14 @@ export enum LOCAL_STORAGE_KEYS {
   DEADLINE_VALUE = "DEADLINE_VALUE",
 }
 
+// FIXME: this and settings.tsx are defining similar things (mostly for the swap-settings & settings inputs)
 export const DEFAULT_DEADLINE = 30; // seconds
-export const DEFAULT_SLIPPAGE = 1; // 0.3%
-export const DEFAULT_SOUND_ENABLED = true; // 1 if true, 0 if false
+export const DEFAULT_SLIPPAGE = 1; // 1%
 export const MAX_INPUT_DEADLINE = 100000; // seconds
+export const MIN_INPUT_DEADLINE = 1; // seconds
+export const MIN_SLIPPAGE = 0.1; // 0.1%
+export const MAX_SLIPPAGE = 100; // 100%
+export const DEFAULT_SOUND_ENABLED = true; // 1 if true, 0 if false
 
 export enum TRANSACTION_TYPES {
   LEGACY = "legacy",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "setenv:bartio": "pnpm run setenv bartio",
     "build:ipfs": "NEXT_PUBLIC_HOST=ipfs turbo build --filter=hub --filter=honey --filter='./packages/*' --concurrency=20",
     "build:hub": "turbo build --filter=hub --filter='./packages/*' --concurrency=20",
+    "dev:hub": "turbo dev --filter=hub --filter='./packages/*' --concurrency=20",
     "build:honey": "turbo build --filter=honey --filter='./packages/*' --concurrency=20",
     "build:storybook": "turbo build --filter=storybook --filter='./packages/*' --concurrency=20  --filter='!b-sdk'",
     "build:lend": "turbo build --filter=lend --filter='./packages/*' --concurrency=20 --filter='!b-sdk'",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "setenv:bartio": "pnpm run setenv bartio",
     "build:ipfs": "NEXT_PUBLIC_HOST=ipfs turbo build --filter=hub --filter=honey --filter='./packages/*' --concurrency=20",
     "build:hub": "turbo build --filter=hub --filter='./packages/*' --concurrency=20",
-    "dev:hub": "turbo dev --filter=hub --filter='./packages/*' --concurrency=20",
     "build:honey": "turbo build --filter=honey --filter='./packages/*' --concurrency=20",
     "build:storybook": "turbo build --filter=storybook --filter='./packages/*' --concurrency=20  --filter='!b-sdk'",
     "build:lend": "turbo build --filter=lend --filter='./packages/*' --concurrency=20 --filter='!b-sdk'",


### PR DESCRIPTION
fix(bex): improve the input sanitation for tx deadline duration + formalize max/min + styling

Specifically this improves the swap settings panel so that DEGEN and INFINITY type deadlines have their values properly displayed.

Previously we just showed the custom value always even if you selected DEGEN/INFINITY.


~~marking this as a draft because I want to fix the duplication between settings swap-settings and constants that exists.~~
OK if we have time I can come back and clean this up, but I think for now this is a [future thing](https://berachain-fe.atlassian.net/browse/BFE-399).

In the near future we'll update look and feel as a part of this [task](https://berachain-fe.atlassian.net/browse/BFE-400), for now this is more of a bugfix. 