### PR TITLE
fix(bex): switch to the ssh remote for secrets 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
 	url = https://github.com/berachain/berancer-sdk.git
 [submodule "secrets"]
 	path = secrets
-	url = https://github.com/berachain/internal-dapps-env.git
+	url = git@github.com:berachain/internal-dapps-env.git


### PR DESCRIPTION
This makes it so that secrets can be pulled without a terminal / https login prompt