### PR TITLE
feat(gov): Split reward vault action to whitelist and blacklist

### DIFF
--- a/apps/hub/src/app/governance/[genre]/create/components/UpdateVaultWhitelistStatus.tsx
+++ b/apps/hub/src/app/governance/[genre]/create/components/UpdateVaultWhitelistStatus.tsx
@@ -11,7 +11,7 @@ import {
 import { InputWithLabel } from "@bera/ui/input";
 import { beraChefAddress } from "@bera/config";
 
-export const UpdateFriendsOfChef = ({
+export const UpdateVaultWhitelistStatus = ({
   action: gauge,
   setAction,
   isFriendOfTheChef,
@@ -19,8 +19,8 @@ export const UpdateFriendsOfChef = ({
 }: {
   action: ProposalAction & {
     type:
-      | ProposalTypeEnum.UPDATE_REWARDS_GAUGE_WHITELIST
-      | ProposalTypeEnum.UPDATE_REWARDS_GAUGE_BLACKLIST;
+      | ProposalTypeEnum.BLACKLIST_REWARD_VAULT
+      | ProposalTypeEnum.WHITELIST_REWARD_VAULT;
   };
   setAction: Dispatch<SetStateAction<ProposalAction>>;
   isFriendOfTheChef: boolean;
@@ -30,8 +30,6 @@ export const UpdateFriendsOfChef = ({
     setAction({
       ...gauge,
       target: beraChefAddress,
-
-      isFriend: isFriendOfTheChef,
     });
   }, [isFriendOfTheChef]);
 

--- a/apps/hub/src/app/governance/[genre]/create/components/UpdateVaultWhitelistStatus.tsx
+++ b/apps/hub/src/app/governance/[genre]/create/components/UpdateVaultWhitelistStatus.tsx
@@ -1,6 +1,6 @@
 import { Dispatch, SetStateAction, useEffect } from "react";
 import { cn } from "@bera/ui";
-import { Address, isAddress } from "viem";
+import { Address } from "viem";
 
 import {
   CustomProposalActionErrors,
@@ -14,7 +14,6 @@ import { beraChefAddress } from "@bera/config";
 export const UpdateVaultWhitelistStatus = ({
   action: gauge,
   setAction,
-  isFriendOfTheChef,
   errors,
 }: {
   action: ProposalAction & {
@@ -23,18 +22,30 @@ export const UpdateVaultWhitelistStatus = ({
       | ProposalTypeEnum.WHITELIST_REWARD_VAULT;
   };
   setAction: Dispatch<SetStateAction<ProposalAction>>;
-  isFriendOfTheChef: boolean;
   errors: CustomProposalActionErrors;
 }) => {
-  useEffect(() => {
-    setAction({
-      ...gauge,
-      target: beraChefAddress,
-    });
-  }, [isFriendOfTheChef]);
-
+  const isWhitelisted = gauge.type === ProposalTypeEnum.WHITELIST_REWARD_VAULT;
   return (
     <>
+      <div className="rounded-md border border-border p-3">
+        <div className="flex gap-2 text-sm font-semibold">
+          <span
+            className={cn(
+              !isWhitelisted
+                ? "text-destructive-foreground"
+                : "text-success-foreground",
+            )}
+          >
+            {isWhitelisted
+              ? "This vault will be able to receive BGT rewards."
+              : "This vault will not be able to receive BGT rewards."}
+          </span>
+        </div>
+        <div className="text-sm font-medium text-muted-foreground">
+          Update this reward vault to be {!isWhitelisted ? "in-" : ""}
+          eligible to receive emissions.
+        </div>
+      </div>
       <div className="flex flex-col gap-2">
         <InputWithLabel
           variant="black"
@@ -50,45 +61,12 @@ export const UpdateVaultWhitelistStatus = ({
           onChange={async (e) => {
             setAction({
               ...gauge,
+              target: beraChefAddress,
               vault: e.target.value as Address,
             });
           }}
         />
-        {/* <div className="text-sm font-semibold leading-tight">Select gauge</div>
-        <GaugeSelector selectedGauge={gauge} setGauge={setAction} />
-        <FormError>
-          {errors.vault === ProposalErrorCodes.REQUIRED
-            ? "A Vault Must Be Chosen"
-            : errors.vault === ProposalErrorCodes.INVALID_ADDRESS
-              ? "Invalid gauge address."
-              : errors.vault}
-        </FormError> */}
       </div>
-
-      {gauge && (
-        <div>
-          <div className="mb-2 text-sm font-semibold leading-tight">Update</div>
-          <div className="rounded-md border border-border p-3">
-            <div className="flex gap-2 text-sm font-semibold">
-              <span
-                className={cn(
-                  !isFriendOfTheChef
-                    ? "text-destructive-foreground"
-                    : "text-success-foreground",
-                )}
-              >
-                {isFriendOfTheChef
-                  ? "This vault will be able to receive BGT rewards."
-                  : "This vault will not be able to receive BGT rewards."}
-              </span>
-            </div>
-            <div className="text-sm font-medium text-muted-foreground">
-              Update this reward vault to be {!isFriendOfTheChef ? "in-" : ""}
-              eligible to receive emissions.
-            </div>
-          </div>
-        </div>
-      )}
     </>
   );
 };

--- a/apps/hub/src/app/governance/[genre]/create/components/create-proposal-action.tsx
+++ b/apps/hub/src/app/governance/[genre]/create/components/create-proposal-action.tsx
@@ -63,8 +63,12 @@ export const CreateProposalAction = ({
               label: "Custom Action",
             },
             {
-              value: ProposalTypeEnum.UPDATE_REWARDS_GAUGE,
-              label: "Update Reward Vault",
+              value: ProposalTypeEnum.UPDATE_REWARDS_GAUGE_WHITELIST,
+              label: "Whitelist Reward Vault Address",
+            },
+            {
+              value: ProposalTypeEnum.UPDATE_REWARDS_GAUGE_BLACKLIST,
+              label: "Blacklist Reward Vault Address",
             },
             // { // TODO add wen we have the treasury contract
             //   value: ProposalTypeEnum.ERC20_TRANSFER,
@@ -89,11 +93,20 @@ export const CreateProposalAction = ({
           idx={idx}
         />
       )}
-      {action.type === ProposalTypeEnum.UPDATE_REWARDS_GAUGE && (
+      {action.type === ProposalTypeEnum.UPDATE_REWARDS_GAUGE_WHITELIST && (
         <UpdateFriendsOfChef
           errors={errors}
           action={action}
           setAction={setAction}
+          isFriendOfTheChef={true}
+        />
+      )}
+      {action.type === ProposalTypeEnum.UPDATE_REWARDS_GAUGE_BLACKLIST && (
+        <UpdateFriendsOfChef
+          errors={errors}
+          action={action}
+          setAction={setAction}
+          isFriendOfTheChef={false}
         />
       )}
       {action.type === ProposalTypeEnum.ERC20_TRANSFER && (

--- a/apps/hub/src/app/governance/[genre]/create/components/create-proposal-action.tsx
+++ b/apps/hub/src/app/governance/[genre]/create/components/create-proposal-action.tsx
@@ -7,10 +7,10 @@ import {
   ProposalAction,
   ProposalTypeEnum,
 } from "~/app/governance/types";
-import { UpdateFriendsOfChef } from "./update-friends-of-chef";
 import { CustomAction } from "./custom-action";
 import { usePrevious } from "@bera/berajs";
 import { Erc20Transfer } from "./erc20-transfer";
+import { UpdateVaultWhitelistStatus } from "./UpdateVaultWhitelistStatus";
 
 export const CreateProposalAction = ({
   action,
@@ -31,7 +31,11 @@ export const CreateProposalAction = ({
 
   useEffect(() => {
     if (prevAction?.type && action.type !== prevAction?.type) {
-      setAction((prev) => ({ type: action.type, calldata: [], target: "" }));
+      setAction((prev) => ({
+        type: action.type,
+        calldata: [],
+        target: "",
+      }));
     }
   }, [action, prevAction]);
 
@@ -63,11 +67,11 @@ export const CreateProposalAction = ({
               label: "Custom Action",
             },
             {
-              value: ProposalTypeEnum.UPDATE_REWARDS_GAUGE_WHITELIST,
+              value: ProposalTypeEnum.WHITELIST_REWARD_VAULT,
               label: "Whitelist Reward Vault Address",
             },
             {
-              value: ProposalTypeEnum.UPDATE_REWARDS_GAUGE_BLACKLIST,
+              value: ProposalTypeEnum.BLACKLIST_REWARD_VAULT,
               label: "Blacklist Reward Vault Address",
             },
             // { // TODO add wen we have the treasury contract
@@ -93,16 +97,16 @@ export const CreateProposalAction = ({
           idx={idx}
         />
       )}
-      {action.type === ProposalTypeEnum.UPDATE_REWARDS_GAUGE_WHITELIST && (
-        <UpdateFriendsOfChef
+      {action.type === ProposalTypeEnum.WHITELIST_REWARD_VAULT && (
+        <UpdateVaultWhitelistStatus
           errors={errors}
           action={action}
           setAction={setAction}
           isFriendOfTheChef={true}
         />
       )}
-      {action.type === ProposalTypeEnum.UPDATE_REWARDS_GAUGE_BLACKLIST && (
-        <UpdateFriendsOfChef
+      {action.type === ProposalTypeEnum.BLACKLIST_REWARD_VAULT && (
+        <UpdateVaultWhitelistStatus
           errors={errors}
           action={action}
           setAction={setAction}

--- a/apps/hub/src/app/governance/[genre]/create/components/create-proposal-action.tsx
+++ b/apps/hub/src/app/governance/[genre]/create/components/create-proposal-action.tsx
@@ -97,20 +97,12 @@ export const CreateProposalAction = ({
           idx={idx}
         />
       )}
-      {action.type === ProposalTypeEnum.WHITELIST_REWARD_VAULT && (
+      {(action.type === ProposalTypeEnum.WHITELIST_REWARD_VAULT ||
+        action.type === ProposalTypeEnum.BLACKLIST_REWARD_VAULT) && (
         <UpdateVaultWhitelistStatus
           errors={errors}
           action={action}
           setAction={setAction}
-          isFriendOfTheChef={true}
-        />
-      )}
-      {action.type === ProposalTypeEnum.BLACKLIST_REWARD_VAULT && (
-        <UpdateVaultWhitelistStatus
-          errors={errors}
-          action={action}
-          setAction={setAction}
-          isFriendOfTheChef={false}
         />
       )}
       {action.type === ProposalTypeEnum.ERC20_TRANSFER && (

--- a/apps/hub/src/app/governance/[genre]/create/components/create-proposal-body.tsx
+++ b/apps/hub/src/app/governance/[genre]/create/components/create-proposal-body.tsx
@@ -1,9 +1,8 @@
 import { Button } from "@bera/ui/button";
 
-import { Icons } from "@bera/ui/icons";
-import { Input, InputWithLabel } from "@bera/ui/input";
+import { InputWithLabel } from "@bera/ui/input";
 import { TextArea } from "@bera/ui/text-area";
-import { Dispatch, SetStateAction, useCallback, useState } from "react";
+import { Dispatch, SetStateAction, useCallback } from "react";
 import {
   CustomProposal,
   CustomProposalErrors,
@@ -11,7 +10,6 @@ import {
 } from "~/app/governance/types";
 import {
   checkProposalField,
-  getBodyErrors,
   type useCreateProposal,
 } from "~/hooks/useCreateProposal";
 import { useGovernance } from "../../components/governance-provider";

--- a/apps/hub/src/app/governance/[genre]/create/components/gauge-selector.tsx
+++ b/apps/hub/src/app/governance/[genre]/create/components/gauge-selector.tsx
@@ -21,7 +21,12 @@ export const GaugeSelector = ({
   setGauge,
 }: {
   selectedGauge:
-    | (ProposalAction & { type: ProposalTypeEnum.UPDATE_REWARDS_GAUGE })
+    | (ProposalAction & {
+        type: ProposalTypeEnum.BLACKLIST_REWARD_VAULT;
+      })
+    | (ProposalAction & {
+        type: ProposalTypeEnum.WHITELIST_REWARD_VAULT;
+      })
     | undefined;
   setGauge: Dispatch<SetStateAction<ProposalAction>>;
 }) => {
@@ -71,14 +76,14 @@ export const GaugeSelector = ({
                     </Link>
                     <span
                       className={cn(
-                        gauge.isFriend
+                        gauge.type === ProposalTypeEnum.WHITELIST_REWARD_VAULT
                           ? "text-success-foreground"
                           : "text-destructive-foreground",
                       )}
                     >
-                      {gauge.isFriend
-                        ? "Reciving Emissions"
-                        : "Not Reciving Emissions"}
+                      {gauge.type === ProposalTypeEnum.WHITELIST_REWARD_VAULT
+                        ? "Receiving Emissions"
+                        : "Not Receiving Emissions"}
                     </span>
                   </div>
                   <div className="text-sm font-medium text-muted-foreground">

--- a/apps/hub/src/app/governance/[genre]/create/components/update-friends-of-chef.tsx
+++ b/apps/hub/src/app/governance/[genre]/create/components/update-friends-of-chef.tsx
@@ -72,11 +72,11 @@ export const UpdateFriendsOfChef = ({
           <div className="mb-2 text-sm font-semibold leading-tight">Update</div>
           <div className="rounded-md border border-border p-3">
             <div className="flex gap-2 text-sm font-semibold">
-              {isFriendOfTheChef ? "Remove" : "Add"} status:{" "}
+              {!isFriendOfTheChef ? "Remove" : "Add"} status:{" "}
               {isAddress(gauge.vault ?? "") ? (
                 <span
                   className={cn(
-                    isFriendOfTheChef
+                    !isFriendOfTheChef
                       ? "text-destructive-foreground"
                       : "text-success-foreground",
                   )}
@@ -88,7 +88,7 @@ export const UpdateFriendsOfChef = ({
               )}
             </div>
             <div className="text-sm font-medium text-muted-foreground">
-              Update this reward vault to be {isFriendOfTheChef ? "in-" : ""}
+              Update this reward vault to be {!isFriendOfTheChef ? "in-" : ""}
               eligible to receive emissions.
             </div>
           </div>

--- a/apps/hub/src/app/governance/[genre]/create/components/update-friends-of-chef.tsx
+++ b/apps/hub/src/app/governance/[genre]/create/components/update-friends-of-chef.tsx
@@ -72,20 +72,17 @@ export const UpdateFriendsOfChef = ({
           <div className="mb-2 text-sm font-semibold leading-tight">Update</div>
           <div className="rounded-md border border-border p-3">
             <div className="flex gap-2 text-sm font-semibold">
-              {!isFriendOfTheChef ? "Remove" : "Add"} status:{" "}
-              {isAddress(gauge.vault ?? "") ? (
-                <span
-                  className={cn(
-                    !isFriendOfTheChef
-                      ? "text-destructive-foreground"
-                      : "text-success-foreground",
-                  )}
-                >
-                  Receiving Emissions
-                </span>
-              ) : (
-                <span>–</span>
-              )}
+              <span
+                className={cn(
+                  !isFriendOfTheChef
+                    ? "text-destructive-foreground"
+                    : "text-success-foreground",
+                )}
+              >
+                {isFriendOfTheChef
+                  ? "This vault will be able to receive BGT rewards."
+                  : "This vault will not be able to receive BGT rewards."}
+              </span>
             </div>
             <div className="text-sm font-medium text-muted-foreground">
               Update this reward vault to be {!isFriendOfTheChef ? "in-" : ""}

--- a/apps/hub/src/app/governance/[genre]/create/components/update-friends-of-chef.tsx
+++ b/apps/hub/src/app/governance/[genre]/create/components/update-friends-of-chef.tsx
@@ -9,30 +9,31 @@ import {
   ProposalTypeEnum,
 } from "~/app/governance/types";
 import { InputWithLabel } from "@bera/ui/input";
-import { useIsFriendOfTheChef } from "@bera/berajs";
 import { beraChefAddress } from "@bera/config";
 
 export const UpdateFriendsOfChef = ({
   action: gauge,
   setAction,
+  isFriendOfTheChef,
   errors,
 }: {
-  action: ProposalAction & { type: ProposalTypeEnum.UPDATE_REWARDS_GAUGE };
+  action: ProposalAction & {
+    type:
+      | ProposalTypeEnum.UPDATE_REWARDS_GAUGE_WHITELIST
+      | ProposalTypeEnum.UPDATE_REWARDS_GAUGE_BLACKLIST;
+  };
   setAction: Dispatch<SetStateAction<ProposalAction>>;
+  isFriendOfTheChef: boolean;
   errors: CustomProposalActionErrors;
 }) => {
-  const { data: isFriendOfTheChef, isLoading } = useIsFriendOfTheChef(
-    gauge.vault,
-  );
-
   useEffect(() => {
     setAction({
       ...gauge,
       target: beraChefAddress,
 
-      isFriend: !isFriendOfTheChef,
+      isFriend: isFriendOfTheChef,
     });
-  }, [isFriendOfTheChef, isLoading]);
+  }, [isFriendOfTheChef]);
 
   return (
     <>

--- a/apps/hub/src/app/governance/helper.ts
+++ b/apps/hub/src/app/governance/helper.ts
@@ -38,7 +38,8 @@ export const getThemeColor = (ProposalType: ProposalTypeEnum) => {
   switch (ProposalType) {
     case ProposalTypeEnum.CUSTOM_PROPOSAL:
       return "foreground";
-    case ProposalTypeEnum.UPDATE_REWARDS_GAUGE:
+    case ProposalTypeEnum.UPDATE_REWARDS_GAUGE_WHITELIST:
+    case ProposalTypeEnum.UPDATE_REWARDS_GAUGE_BLACKLIST:
       return "info-foreground";
     default:
       return "foreground";

--- a/apps/hub/src/app/governance/helper.ts
+++ b/apps/hub/src/app/governance/helper.ts
@@ -38,8 +38,8 @@ export const getThemeColor = (ProposalType: ProposalTypeEnum) => {
   switch (ProposalType) {
     case ProposalTypeEnum.CUSTOM_PROPOSAL:
       return "foreground";
-    case ProposalTypeEnum.UPDATE_REWARDS_GAUGE_WHITELIST:
-    case ProposalTypeEnum.UPDATE_REWARDS_GAUGE_BLACKLIST:
+    case ProposalTypeEnum.WHITELIST_REWARD_VAULT:
+    case ProposalTypeEnum.BLACKLIST_REWARD_VAULT:
       return "info-foreground";
     default:
       return "foreground";

--- a/apps/hub/src/app/governance/types.ts
+++ b/apps/hub/src/app/governance/types.ts
@@ -52,7 +52,8 @@ export type CustomProposalErrors = {
 
 export enum ProposalTypeEnum {
   CUSTOM_PROPOSAL = "custom-proposal",
-  UPDATE_REWARDS_GAUGE = "update-rewards-gauge",
+  UPDATE_REWARDS_GAUGE_WHITELIST = "update-rewards-gauge-whitelist",
+  UPDATE_REWARDS_GAUGE_BLACKLIST = "update-rewards-gauge-blacklist",
   ERC20_TRANSFER = "erc20-transfer",
 }
 export enum ProposalErrorCodes {
@@ -89,7 +90,13 @@ export type SafeProposalAction = {
       calldata: string[];
     }
   | {
-      type: ProposalTypeEnum.UPDATE_REWARDS_GAUGE;
+      type: ProposalTypeEnum.UPDATE_REWARDS_GAUGE_WHITELIST;
+      vault: Address;
+      isFriend: boolean;
+      metadata?: string | undefined;
+    }
+  | {
+      type: ProposalTypeEnum.UPDATE_REWARDS_GAUGE_BLACKLIST;
       vault: Address;
       isFriend: boolean;
       metadata?: string | undefined;

--- a/apps/hub/src/app/governance/types.ts
+++ b/apps/hub/src/app/governance/types.ts
@@ -52,8 +52,8 @@ export type CustomProposalErrors = {
 
 export enum ProposalTypeEnum {
   CUSTOM_PROPOSAL = "custom-proposal",
-  UPDATE_REWARDS_GAUGE_WHITELIST = "update-rewards-gauge-whitelist",
-  UPDATE_REWARDS_GAUGE_BLACKLIST = "update-rewards-gauge-blacklist",
+  WHITELIST_REWARD_VAULT = "whitelist-reward-vault",
+  BLACKLIST_REWARD_VAULT = "blacklist-reward-vault",
   ERC20_TRANSFER = "erc20-transfer",
 }
 export enum ProposalErrorCodes {
@@ -90,15 +90,13 @@ export type SafeProposalAction = {
       calldata: string[];
     }
   | {
-      type: ProposalTypeEnum.UPDATE_REWARDS_GAUGE_WHITELIST;
+      type: ProposalTypeEnum.WHITELIST_REWARD_VAULT;
       vault: Address;
-      isFriend: boolean;
       metadata?: string | undefined;
     }
   | {
-      type: ProposalTypeEnum.UPDATE_REWARDS_GAUGE_BLACKLIST;
+      type: ProposalTypeEnum.BLACKLIST_REWARD_VAULT;
       vault: Address;
-      isFriend: boolean;
       metadata?: string | undefined;
     }
   | {

--- a/apps/hub/src/hooks/useCreateProposal.ts
+++ b/apps/hub/src/hooks/useCreateProposal.ts
@@ -351,7 +351,9 @@ export const useCreateProposal = ({
                 errors.functionSignature = ProposalErrorCodes.INVALID_ABI;
               }
             }
-          } else if (action.type === ProposalTypeEnum.UPDATE_REWARDS_GAUGE) {
+          } else if (
+            action.type === ProposalTypeEnum.UPDATE_REWARDS_GAUGE_WHITELIST
+          ) {
             errors.vault = checkProposalField({
               fieldOrType: "address",
               value: action.vault,
@@ -361,11 +363,22 @@ export const useCreateProposal = ({
               actions[idx] = encodeFunctionData({
                 abi: BERA_CHEF_ABI,
                 functionName: "setVaultWhitelistedStatus",
-                args: [
-                  action.vault!,
-                  !!action.isFriend!,
-                  action.metadata ?? "",
-                ], // TODO: A third param was added for metadata. It is optional but we should include it in our action
+                args: [action.vault!, true, action.metadata ?? ""], // TODO: A third param was added for metadata. It is optional but we should include it in our action
+              });
+            }
+          } else if (
+            action.type === ProposalTypeEnum.UPDATE_REWARDS_GAUGE_BLACKLIST
+          ) {
+            errors.vault = checkProposalField({
+              fieldOrType: "address",
+              value: action.vault,
+            });
+            errors.isFriend = null; //checkProposalField("bool", action.isFriend);
+            if (!errors.vault) {
+              actions[idx] = encodeFunctionData({
+                abi: BERA_CHEF_ABI,
+                functionName: "setVaultWhitelistedStatus",
+                args: [action.vault!, false, action.metadata ?? ""], // TODO: A third param was added for metadata. It is optional but we should include it in our action
               });
             }
           } else if (action.type === ProposalTypeEnum.ERC20_TRANSFER) {

--- a/apps/hub/src/hooks/useCreateProposal.ts
+++ b/apps/hub/src/hooks/useCreateProposal.ts
@@ -352,33 +352,23 @@ export const useCreateProposal = ({
               }
             }
           } else if (
-            action.type === ProposalTypeEnum.UPDATE_REWARDS_GAUGE_WHITELIST
+            action.type === ProposalTypeEnum.WHITELIST_REWARD_VAULT ||
+            action.type === ProposalTypeEnum.BLACKLIST_REWARD_VAULT
           ) {
             errors.vault = checkProposalField({
               fieldOrType: "address",
               value: action.vault,
             });
             errors.isFriend = null; //checkProposalField("bool", action.isFriend);
+            const whiteList =
+              action.type === ProposalTypeEnum.WHITELIST_REWARD_VAULT
+                ? true
+                : false;
             if (!errors.vault) {
               actions[idx] = encodeFunctionData({
                 abi: BERA_CHEF_ABI,
                 functionName: "setVaultWhitelistedStatus",
-                args: [action.vault!, true, action.metadata ?? ""], // TODO: A third param was added for metadata. It is optional but we should include it in our action
-              });
-            }
-          } else if (
-            action.type === ProposalTypeEnum.UPDATE_REWARDS_GAUGE_BLACKLIST
-          ) {
-            errors.vault = checkProposalField({
-              fieldOrType: "address",
-              value: action.vault,
-            });
-            errors.isFriend = null; //checkProposalField("bool", action.isFriend);
-            if (!errors.vault) {
-              actions[idx] = encodeFunctionData({
-                abi: BERA_CHEF_ABI,
-                functionName: "setVaultWhitelistedStatus",
-                args: [action.vault!, false, action.metadata ?? ""], // TODO: A third param was added for metadata. It is optional but we should include it in our action
+                args: [action.vault!, whiteList, action.metadata ?? ""], // TODO: A third param was added for metadata. It is optional but we should include it in our action
               });
             }
           } else if (action.type === ProposalTypeEnum.ERC20_TRANSFER) {
@@ -440,6 +430,10 @@ export const useCreateProposal = ({
         version: "1.0.0",
         "content-encoding": "utf-8",
         "content-type": "text/markdown",
+        actions: proposal.actions.map((action, idx) => ({
+          type: action.type,
+          description: "more stuff",
+        })),
       });
 
       write({

--- a/packages/berajs/src/actions/governance/computeActualStatus.ts
+++ b/packages/berajs/src/actions/governance/computeActualStatus.ts
@@ -29,6 +29,7 @@ export function computeActualStatus(
     if (proposal.status === ProposalStatus.CanceledByGuardian) {
       return ProposalStatus.CanceledByGuardian;
     }
+
     if (proposalOnChainState === ProposalState.Canceled) {
       if (proposal.voteStartBlock < currentBlock)
         return ProposalStatus.CanceledByUser;
@@ -46,7 +47,7 @@ export function computeActualStatus(
       ) {
         return ProposalStatus.QuorumNotReached;
       }
-      return ProposalStatus.Defeated; //
+      return ProposalStatus.Defeated;
     }
 
     if (proposalOnChainState === ProposalState.Succeeded)


### PR DESCRIPTION
Currently there is a single action that flips the boolean for white/blacklisting of a reward vault address.
This PR splits this into 2 separate actions that specifically white or blacklist



![Screenshot 2024-12-19 at 16 39 44](https://github.com/user-attachments/assets/662c317a-6682-42a6-8c2a-45ac8bbbe602)
![Screenshot 2024-12-19 at 16 39 38](https://github.com/user-attachments/assets/ce626d90-3494-4b55-91d5-99efee22e559)
