### PR TITLE
refactor: using computed properties to robots.ts

### DIFF
--- a/apps/honey/src/app/robots.ts
+++ b/apps/honey/src/app/robots.ts
@@ -2,19 +2,10 @@ import { MetadataRoute } from "next";
 import { isIPFS } from "@bera/config";
 
 export default function robots(): MetadataRoute.Robots {
-  if (isIPFS || process.env.DONT_INDEX === "1") {
-    return {
-      rules: {
-        userAgent: "*",
-        disallow: "/",
-      },
-    };
-  }
-
   return {
     rules: {
       userAgent: "*",
-      allow: "/",
+      [isIPFS || process.env.DONT_INDEX === "1" ? "disallow" : "allow"]: "/",
     },
   };
 }

--- a/apps/hub/src/app/robots.ts
+++ b/apps/hub/src/app/robots.ts
@@ -2,19 +2,10 @@ import { MetadataRoute } from "next";
 import { isIPFS } from "@bera/config";
 
 export default function robots(): MetadataRoute.Robots {
-  if (isIPFS || process.env.DONT_INDEX === "1") {
-    return {
-      rules: {
-        userAgent: "*",
-        disallow: "/",
-      },
-    };
-  }
-
   return {
     rules: {
       userAgent: "*",
-      allow: "/",
+      [isIPFS || process.env.DONT_INDEX === "1" ? "disallow" : "allow"]: "/",
     },
   };
 }

--- a/apps/lend/src/app/robots.ts
+++ b/apps/lend/src/app/robots.ts
@@ -2,19 +2,10 @@ import { MetadataRoute } from "next";
 import { isIPFS } from "@bera/config";
 
 export default function robots(): MetadataRoute.Robots {
-  if (isIPFS || process.env.DONT_INDEX === "1") {
-    return {
-      rules: {
-        userAgent: "*",
-        disallow: "/",
-      },
-    };
-  }
-
   return {
     rules: {
       userAgent: "*",
-      allow: "/",
+      [isIPFS || process.env.DONT_INDEX === "1" ? "disallow" : "allow"]: "/",
     },
   };
 }

--- a/apps/perp/src/app/robots.ts
+++ b/apps/perp/src/app/robots.ts
@@ -2,19 +2,10 @@ import { MetadataRoute } from "next";
 import { isIPFS } from "@bera/config";
 
 export default function robots(): MetadataRoute.Robots {
-  if (isIPFS || process.env.DONT_INDEX === "1") {
-    return {
-      rules: {
-        userAgent: "*",
-        disallow: "/",
-      },
-    };
-  }
-
   return {
     rules: {
       userAgent: "*",
-      allow: "/",
+      [isIPFS || process.env.DONT_INDEX === "1" ? "disallow" : "allow"]: "/",
     },
   };
 }


### PR DESCRIPTION
## Current Situation
The `robots.ts` files in our apps contain redundant code structure with repeated object literals for handling allow/disallow rules.

Before:
```
if (isIPFS || process.env.DONT_INDEX === "1") {
    return {
      rules: {
        userAgent: "*",
        disallow: "/",
      },
    };
  }

  return {
    rules: {
      userAgent: "*",
      allow: "/",
    },
  };
```
After:
```
return {
    rules: {
      userAgent: "*",
      [isIPFS || process.env.DONT_INDEX === "1" ? "disallow" : "allow"]: "/",
    },
  };
```

## Testing
- [ ] Verified that robots.txt still generates correctly in development

## Type of Change
- [x] Code refactoring (no functional changes)
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

it can resolved this [issue](https://github.com/berachain/monobera/issues/287)