### PR TITLE
Fix Typo in `charting-library.d.ts`

### DIFF
--- a/apps/perp/src/types/charting-library.d.ts
+++ b/apps/perp/src/types/charting-library.d.ts
@@ -7965,7 +7965,7 @@ export interface IChartWidgetApi {
    */
   setPriceToBarRatioLocked(value: boolean, options?: UndoOptions): void;
   /**
-   * Get an array of the heigh of all panes.
+   * Get an array of the height of all panes.
    *
    * **Example**
    * ```javascript


### PR DESCRIPTION
# Pull Request Title
Fix Typo in `charting-library.d.ts`

## Description
Corrected a typo in the `charting-library.d.ts` file to improve code comments for better readability and accuracy.

### Changes Made:
- **File Modified:** `apps/perp/src/types/charting-library.d.ts`
- **Summary of Changes:**  
  - Line 7965: Replaced "heigh" with "height" in the comment for the `setPriceToBarRatioLocked` method.

## Related Issues
<!-- If applicable, link to any issues this PR addresses. -->
N/A

## Checklist
- [x] The change follows the project's [contributing guidelines](link-to-contributing-guidelines).
- [x] The updated comment accurately describes the functionality.
- [x] No functionality of the code is impacted.

## Testing
<!-- Describe how you validated the change, if applicable. -->
- N/A (Comment update only)

## Additional Notes
<!-- Add any additional comments for reviewers. -->
This is a minor typo fix in the documentation within the code. Please confirm that no other similar typos exist in the file.

---

**Allow edits by maintainers:** [x]
<!-- Check this box to allow maintainers to modify the pull request if needed. -->
