### PR TITLE
feat(gov): Add governance action metadata

### DIFF
--- a/apps/hub/src/app/governance/[genre]/components/user-voting-power.tsx
+++ b/apps/hub/src/app/governance/[genre]/components/user-voting-power.tsx
@@ -57,7 +57,7 @@ export const UserVotingPower = () => {
                       : truncateHash(data?.delegate)}
                   </div>
                 ) : (
-                  <p className="sm:flex items-center gap-1">
+                  <div className="sm:flex items-center gap-1">
                     <span className="leading-none max-sm:grow flex">
                       Unassigned
                     </span>
@@ -76,7 +76,7 @@ export const UserVotingPower = () => {
                       )}
                       <TokenIcon size="md" address={governanceTokenAddress} />
                     </p>
-                  </p>
+                  </div>
                 )
               ) : (
                 <Skeleton className="h-6 w-full" />
@@ -88,20 +88,18 @@ export const UserVotingPower = () => {
               Delegations (from other wallets)
             </div>
             {data?.delegate ? (
-              <p className="flex items-center gap-2">
-                <p className="flex items-center gap-1">
-                  {delegatedByOthers ? (
-                    <FormattedNumber
-                      className="text-primary font-medium"
-                      value={delegatedByOthers}
-                      symbol="BGT"
-                      compact={true}
-                    />
-                  ) : (
-                    <Skeleton className="h-6 w-full" />
-                  )}
-                  <TokenIcon size="md" address={governanceTokenAddress} />
-                </p>
+              <p className="flex items-center gap-1">
+                {delegatedByOthers ? (
+                  <FormattedNumber
+                    className="text-primary font-medium"
+                    value={delegatedByOthers}
+                    symbol="BGT"
+                    compact={true}
+                  />
+                ) : (
+                  <Skeleton className="h-6 w-full" />
+                )}
+                <TokenIcon size="md" address={governanceTokenAddress} />
               </p>
             ) : (
               <Skeleton className="h-6 w-full" />

--- a/apps/hub/src/app/governance/[genre]/create/components/UpdateVaultWhitelistStatus.tsx
+++ b/apps/hub/src/app/governance/[genre]/create/components/UpdateVaultWhitelistStatus.tsx
@@ -2,13 +2,7 @@ import { Dispatch, SetStateAction } from "react";
 import { beraChefAddress } from "@bera/config";
 import { cn } from "@bera/ui";
 import { InputWithLabel } from "@bera/ui/input";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@bera/ui/select";
+import { Dropdown } from "@bera/shared-ui";
 import { TextArea } from "@bera/ui/text-area";
 
 import { Address } from "viem";
@@ -20,6 +14,7 @@ import {
   ProposalTypeEnum,
 } from "~/app/governance/types";
 import { useGaugesMetadata } from "@bera/berajs";
+import { Label } from "@bera/ui/label";
 
 export const UpdateVaultWhitelistStatus = ({
   action: gauge,
@@ -44,7 +39,7 @@ export const UpdateVaultWhitelistStatus = ({
 }) => {
   const { data: rewardVaultMetadata } = useGaugesMetadata();
 
-  const protocolValues =
+  const protocolValues = ((rewardVaultMetadata &&
     Object.values(
       rewardVaultMetadata as Record<
         `0x${string}`,
@@ -52,7 +47,7 @@ export const UpdateVaultWhitelistStatus = ({
           product: string;
         }
       >,
-    ).map((v) => v.product) || [];
+    ).map((v) => v.product)) as string[]) || ["Loading..."];
 
   const protocolArray = [...new Set(protocolValues).values()];
 
@@ -98,117 +93,83 @@ export const UpdateVaultWhitelistStatus = ({
             });
           }}
         />
-        {isWhitelisted && (
-          <>
-            <InputWithLabel
-              variant="black"
-              label="Name"
-              value={gauge.metadata?.name}
-              error={
-                errors?.metadata?.name === ProposalErrorCodes.REQUIRED
-                  ? "Name must be filled"
-                  : errors?.metadata?.name
-              }
-              maxLength={40}
-              onChange={async (e) => {
-                setAction((prev) => ({
-                  ...prev,
-                  metadata: { ...prev.metadata, name: e.target.value },
-                }));
-              }}
-            />
-            <InputWithLabel
-              variant="black"
-              label="Logo URI"
-              value={gauge.metadata?.logoURI}
-              error={
-                errors?.metadata?.logoURI === ProposalErrorCodes.REQUIRED
-                  ? "Logo URI must be filled"
-                  : errors?.metadata?.logoURI ===
-                      ProposalErrorCodes.MUST_BE_URL_OR_IPFS
-                    ? "Must be a valid URL or IPFS CID"
-                    : errors?.metadata?.logoURI
-              }
-              onChange={async (e) => {
-                setAction((prev) => ({
-                  ...prev,
-                  metadata: { ...prev.metadata, logoURI: e.target.value },
-                }));
-              }}
-            />
-            {/* <InputWithLabel
-              variant="black"
-              label="Product"
-              value={gauge.metadata?.protocol}
-              error={
-                errors?.vault === ProposalErrorCodes.REQUIRED
-                  ? "A Vault Must Be Chosen"
-                  : errors?.vault === ProposalErrorCodes.INVALID_ADDRESS
-                    ? "Invalid Vault address."
-                    : errors?.vault
-              }
-              onChange={async (e) => {
-                setAction((prev) => ({
-                  ...prev,
-                  metadata: { ...prev.metadata, protocol: e.target.value },
-                }));
-              }}
-            /> */}
-            <Select
-              onValueChange={(value) =>
-                setAction((prev) => ({
-                  ...prev,
-                  metadata: { ...prev.metadata, protocol: value },
-                }))
-              }
-            >
-              <SelectTrigger>
-                <SelectValue>{gauge.metadata?.protocol}</SelectValue>
-              </SelectTrigger>
-              <SelectContent>
-                {protocolArray.map((protocol) => (
-                  <SelectItem value={protocol}>{protocol}</SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            <InputWithLabel
-              variant="black"
-              label="URL"
-              value={gauge.metadata?.url}
-              error={
-                errors?.metadata?.url === ProposalErrorCodes.REQUIRED
-                  ? "You must set a URL"
-                  : errors?.metadata?.url === ProposalErrorCodes.MUST_BE_URL
-                    ? "Must be a valid HTTPS or HTTP url"
-                    : errors?.metadata?.url
-              }
-              onChange={async (e) => {
-                setAction((prev) => ({
-                  ...prev,
-                  metadata: { ...prev.metadata, url: e.target.value },
-                }));
-              }}
-            />
-            <TextArea
-              id="proposal-message"
-              label="Description"
-              error={
-                errors?.metadata?.description === ProposalErrorCodes.REQUIRED
-                  ? "Description must be filled"
-                  : null
-              }
-              variant="black"
-              placeholder="Tell us about this vault"
-              value={gauge.metadata?.description}
-              onChange={(e) =>
-                setAction((prev) => ({
-                  ...prev,
-                  metadata: { ...prev.metadata, description: e.target.value },
-                }))
-              }
-            />
-          </>
-        )}
+        <InputWithLabel
+          variant="black"
+          label="Name"
+          value={gauge.metadata?.name}
+          error={null}
+          maxLength={40}
+          onChange={async (e) => {
+            setAction((prev) => ({
+              ...prev,
+              metadata: { ...prev.metadata, name: e.target.value },
+            }));
+          }}
+        />
+        <InputWithLabel
+          variant="black"
+          label="Logo URI"
+          value={gauge.metadata?.logoURI}
+          error={
+            errors?.metadata?.logoURI === ProposalErrorCodes.MUST_BE_URL_OR_IPFS
+              ? "Must be a valid URL or IPFS CID"
+              : errors?.metadata?.logoURI
+          }
+          onChange={async (e) => {
+            setAction((prev) => ({
+              ...prev,
+              metadata: { ...prev.metadata, logoURI: e.target.value },
+            }));
+          }}
+        />
+        <Label>Protocol</Label>
+        <Dropdown
+          sortby={false}
+          className="!w-full !grow"
+          triggerClassName="!w-full grow justify-between"
+          contentClassname="!w-full !grow"
+          selectionList={protocolArray.map((protocol) => ({
+            value: protocol,
+            label: protocol,
+          }))}
+          selected={gauge.metadata?.protocol || protocolArray[0]}
+          onSelect={(value) =>
+            setAction((prev) => ({
+              ...prev,
+              metadata: { ...prev.metadata, protocol: value },
+            }))
+          }
+        />
+        <InputWithLabel
+          variant="black"
+          label="URL"
+          value={gauge.metadata?.url}
+          error={
+            errors?.metadata?.url === ProposalErrorCodes.MUST_BE_URL
+              ? "Must be a valid HTTPS or HTTP url"
+              : errors?.metadata?.url
+          }
+          onChange={async (e) => {
+            setAction((prev) => ({
+              ...prev,
+              metadata: { ...prev.metadata, url: e.target.value },
+            }));
+          }}
+        />
+        <TextArea
+          id="proposal-message"
+          label="Description"
+          error={null}
+          variant="black"
+          placeholder="Tell us about this vault"
+          value={gauge.metadata?.description}
+          onChange={(e) =>
+            setAction((prev) => ({
+              ...prev,
+              metadata: { ...prev.metadata, description: e.target.value },
+            }))
+          }
+        />
       </div>
     </>
   );

--- a/apps/hub/src/app/governance/[genre]/create/components/UpdateVaultWhitelistStatus.tsx
+++ b/apps/hub/src/app/governance/[genre]/create/components/UpdateVaultWhitelistStatus.tsx
@@ -20,6 +20,7 @@ export const UpdateVaultWhitelistStatus = ({
   action: gauge,
   setAction,
   errors,
+  id,
 }: {
   action: ProposalAction & {
     type:
@@ -36,6 +37,7 @@ export const UpdateVaultWhitelistStatus = ({
     >
   >;
   errors: CustomProposalActionErrors;
+  id: number | string;
 }) => {
   const { data: rewardVaultMetadata } = useGaugesMetadata();
 
@@ -78,7 +80,7 @@ export const UpdateVaultWhitelistStatus = ({
       </div>
       <div className="grid grid-cols-1 gap-6">
         <InputWithLabel
-          id="vault-address"
+          id={`${id}-vault-address`}
           variant="black"
           placeholder="0x..."
           label="Reward Vault Address"
@@ -100,7 +102,7 @@ export const UpdateVaultWhitelistStatus = ({
         />
         <InputWithLabel
           variant="black"
-          id="vault-name"
+          id={`${id}-vault-name`}
           label="Name"
           placeholder="Name of the vault"
           value={gauge.metadata?.name}
@@ -115,7 +117,7 @@ export const UpdateVaultWhitelistStatus = ({
         />
         <InputWithLabel
           variant="black"
-          id="vault-logo-uri"
+          id={`${id}-vault-logo-uri`}
           label="Logo URI"
           placeholder="https:// or ipfs://"
           value={gauge.metadata?.logoURI}
@@ -154,7 +156,7 @@ export const UpdateVaultWhitelistStatus = ({
         </div>
         <InputWithLabel
           variant="black"
-          id="vault-url"
+          id={`${id}-vault-url`}
           label="URL"
           placeholder="https://"
           value={gauge.metadata?.url}
@@ -167,7 +169,7 @@ export const UpdateVaultWhitelistStatus = ({
           }}
         />
         <TextArea
-          id="vault-description"
+          id={`${id}-vault-description`}
           label="Description"
           error={errors?.metadata?.description}
           variant="black"

--- a/apps/hub/src/app/governance/[genre]/create/components/UpdateVaultWhitelistStatus.tsx
+++ b/apps/hub/src/app/governance/[genre]/create/components/UpdateVaultWhitelistStatus.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction, useEffect, useState } from "react";
+import { Dispatch, SetStateAction } from "react";
 import { beraChefAddress } from "@bera/config";
 import { cn } from "@bera/ui";
 import { InputWithLabel } from "@bera/ui/input";
@@ -10,8 +10,7 @@ import {
   SelectValue,
 } from "@bera/ui/select";
 import { TextArea } from "@bera/ui/text-area";
-import { set } from "date-fns";
-import matter from "gray-matter";
+
 import { Address } from "viem";
 
 import {
@@ -20,8 +19,7 @@ import {
   ProposalErrorCodes,
   ProposalTypeEnum,
 } from "~/app/governance/types";
-
-const products = ["Product 1", "Product 2"];
+import { useGaugesMetadata } from "@bera/berajs";
 
 export const UpdateVaultWhitelistStatus = ({
   action: gauge,
@@ -33,43 +31,30 @@ export const UpdateVaultWhitelistStatus = ({
       | ProposalTypeEnum.BLACKLIST_REWARD_VAULT
       | ProposalTypeEnum.WHITELIST_REWARD_VAULT;
   };
-  setAction: Dispatch<SetStateAction<ProposalAction>>;
+  setAction: Dispatch<
+    SetStateAction<
+      ProposalAction & {
+        type:
+          | ProposalTypeEnum.BLACKLIST_REWARD_VAULT
+          | ProposalTypeEnum.WHITELIST_REWARD_VAULT;
+      }
+    >
+  >;
   errors: CustomProposalActionErrors;
 }) => {
-  const [metadata, setMetadata] = useState<{
-    name?: string;
-    logoURI?: string;
-    product?: string;
-    url?: string;
-    description?: string;
-  }>();
+  const { data: rewardVaultMetadata } = useGaugesMetadata();
 
-  const nameLengthError =
-    metadata?.name && metadata?.name?.length > 40
-      ? "Name must be less than 40 characters"
-      : null;
+  const protocolValues =
+    Object.values(
+      rewardVaultMetadata as Record<
+        `0x${string}`,
+        {
+          product: string;
+        }
+      >,
+    ).map((v) => v.product) || [];
 
-  // The logoURI is either a https or http or ipfs cid. It is checked with a regex
-  const logoURIError =
-    metadata?.logoURI &&
-    !/(http|https|ipfs):\/\/[^ "]+$/.test(metadata?.logoURI)
-      ? "Invalid URI"
-      : null;
-
-  const descriptionToolLongError = metadata?.description
-    ? metadata?.description.length > 1000
-      ? `Description must be less than 1000 characters. Current length: ${metadata?.description.length}`
-      : null
-    : null;
-
-  useEffect(() => {
-    if (!metadata?.description) return;
-    const string = matter.stringify(metadata.description, metadata);
-    setAction((prev) => ({
-      ...prev,
-      metadata: string,
-    }));
-  }, [metadata]);
+  const protocolArray = [...new Set(protocolValues).values()];
 
   const isWhitelisted = gauge.type === ProposalTypeEnum.WHITELIST_REWARD_VAULT;
   return (
@@ -118,33 +103,43 @@ export const UpdateVaultWhitelistStatus = ({
             <InputWithLabel
               variant="black"
               label="Name"
-              value={metadata?.name}
-              error={nameLengthError}
+              value={gauge.metadata?.name}
+              error={
+                errors?.metadata?.name === ProposalErrorCodes.REQUIRED
+                  ? "Name must be filled"
+                  : errors?.metadata?.name
+              }
               maxLength={40}
               onChange={async (e) => {
-                setMetadata({
-                  ...metadata,
-                  name: e.target.value,
-                });
+                setAction((prev) => ({
+                  ...prev,
+                  metadata: { ...prev.metadata, name: e.target.value },
+                }));
               }}
             />
-            {metadata?.name}
             <InputWithLabel
               variant="black"
               label="Logo URI"
-              value={metadata?.logoURI}
-              error={logoURIError}
+              value={gauge.metadata?.logoURI}
+              error={
+                errors?.metadata?.logoURI === ProposalErrorCodes.REQUIRED
+                  ? "Logo URI must be filled"
+                  : errors?.metadata?.logoURI ===
+                      ProposalErrorCodes.MUST_BE_URL_OR_IPFS
+                    ? "Must be a valid URL or IPFS CID"
+                    : errors?.metadata?.logoURI
+              }
               onChange={async (e) => {
-                setMetadata({
-                  ...metadata,
-                  logoURI: e.target.value,
-                });
+                setAction((prev) => ({
+                  ...prev,
+                  metadata: { ...prev.metadata, logoURI: e.target.value },
+                }));
               }}
             />
-            <InputWithLabel
+            {/* <InputWithLabel
               variant="black"
               label="Product"
-              value={metadata?.product}
+              value={gauge.metadata?.protocol}
               error={
                 errors?.vault === ProposalErrorCodes.REQUIRED
                   ? "A Vault Must Be Chosen"
@@ -153,63 +148,65 @@ export const UpdateVaultWhitelistStatus = ({
                     : errors?.vault
               }
               onChange={async (e) => {
-                setMetadata({
-                  ...metadata,
-                  product: e.target.value,
-                });
+                setAction((prev) => ({
+                  ...prev,
+                  metadata: { ...prev.metadata, protocol: e.target.value },
+                }));
               }}
-            />
+            /> */}
             <Select
               onValueChange={(value) =>
-                setMetadata({ ...metadata, product: value })
+                setAction((prev) => ({
+                  ...prev,
+                  metadata: { ...prev.metadata, protocol: value },
+                }))
               }
             >
               <SelectTrigger>
-                <SelectValue>{metadata?.product}</SelectValue>
+                <SelectValue>{gauge.metadata?.protocol}</SelectValue>
               </SelectTrigger>
               <SelectContent>
-                {products.map((product) => (
-                  <SelectItem value={product}>{product}</SelectItem>
+                {protocolArray.map((protocol) => (
+                  <SelectItem value={protocol}>{protocol}</SelectItem>
                 ))}
               </SelectContent>
             </Select>
             <InputWithLabel
               variant="black"
               label="URL"
-              value={metadata?.url}
+              value={gauge.metadata?.url}
               error={
-                errors?.vault === ProposalErrorCodes.REQUIRED
-                  ? "A Vault Must Be Chosen"
-                  : errors?.vault === ProposalErrorCodes.INVALID_ADDRESS
-                    ? "Invalid Vault address."
-                    : errors?.vault
+                errors?.metadata?.url === ProposalErrorCodes.REQUIRED
+                  ? "You must set a URL"
+                  : errors?.metadata?.url === ProposalErrorCodes.MUST_BE_URL
+                    ? "Must be a valid HTTPS or HTTP url"
+                    : errors?.metadata?.url
               }
               onChange={async (e) => {
-                setMetadata({
-                  ...metadata,
-                  url: e.target.value,
-                });
+                setAction((prev) => ({
+                  ...prev,
+                  metadata: { ...prev.metadata, url: e.target.value },
+                }));
               }}
             />
             <TextArea
               id="proposal-message"
               label="Description"
-              // error={
-              //   errors.description === ProposalErrorCodes.REQUIRED
-              //     ? "Description must be filled"
-              //     : errors.description
-              // }
+              error={
+                errors?.metadata?.description === ProposalErrorCodes.REQUIRED
+                  ? "Description must be filled"
+                  : null
+              }
               variant="black"
-              error={descriptionToolLongError}
               placeholder="Tell us about this vault"
-              value={metadata?.description}
+              value={gauge.metadata?.description}
               onChange={(e) =>
-                setMetadata((prev: any) => ({
+                setAction((prev) => ({
                   ...prev,
-                  description: e.target.value,
+                  metadata: { ...prev.metadata, description: e.target.value },
                 }))
               }
-            />{" "}
+            />
           </>
         )}
       </div>

--- a/apps/hub/src/app/governance/[genre]/create/components/UpdateVaultWhitelistStatus.tsx
+++ b/apps/hub/src/app/governance/[genre]/create/components/UpdateVaultWhitelistStatus.tsx
@@ -113,7 +113,7 @@ export const UpdateVaultWhitelistStatus = ({
           error={
             errors?.metadata?.logoURI ===
             ProposalErrorCodes.MUST_BE_HTTPS_OR_IPFS
-              ? "Must be a valid URL or IPFS CID"
+              ? ProposalErrorCodes.MUST_BE_HTTPS_OR_IPFS
               : errors?.metadata?.logoURI
           }
           onChange={async (e) => {
@@ -149,7 +149,7 @@ export const UpdateVaultWhitelistStatus = ({
           value={gauge.metadata?.url}
           error={
             errors?.metadata?.url === ProposalErrorCodes.MUST_BE_HTTPS
-              ? "Must be a valid HTTPS url"
+              ? ProposalErrorCodes.MUST_BE_HTTPS
               : errors?.metadata?.url
           }
           onChange={async (e) => {

--- a/apps/hub/src/app/governance/[genre]/create/components/UpdateVaultWhitelistStatus.tsx
+++ b/apps/hub/src/app/governance/[genre]/create/components/UpdateVaultWhitelistStatus.tsx
@@ -125,9 +125,9 @@ export const UpdateVaultWhitelistStatus = ({
         <Label>Protocol</Label>
         <Dropdown
           sortby={false}
-          className="!w-full !grow"
-          triggerClassName="!w-full grow justify-between"
-          contentClassname="!w-full !grow"
+          className="!w-full !grow bg-black rounded-md"
+          triggerClassName="!w-full grow justify-between bg-black"
+          contentClassname="!w-full !grow bg-black"
           selectionList={protocolArray.map((protocol) => ({
             value: protocol,
             label: protocol,

--- a/apps/hub/src/app/governance/[genre]/create/components/UpdateVaultWhitelistStatus.tsx
+++ b/apps/hub/src/app/governance/[genre]/create/components/UpdateVaultWhitelistStatus.tsx
@@ -73,7 +73,7 @@ export const UpdateVaultWhitelistStatus = ({
           eligible to receive emissions.
         </div>
       </div>
-      <div className="flex flex-col gap-2">
+      <div className="grid grid-cols-1 gap-6">
         <InputWithLabel
           variant="black"
           label="Reward Vault Address"
@@ -111,7 +111,8 @@ export const UpdateVaultWhitelistStatus = ({
           label="Logo URI"
           value={gauge.metadata?.logoURI}
           error={
-            errors?.metadata?.logoURI === ProposalErrorCodes.MUST_BE_URL_OR_IPFS
+            errors?.metadata?.logoURI ===
+            ProposalErrorCodes.MUST_BE_HTTPS_OR_IPFS
               ? "Must be a valid URL or IPFS CID"
               : errors?.metadata?.logoURI
           }
@@ -122,31 +123,33 @@ export const UpdateVaultWhitelistStatus = ({
             }));
           }}
         />
-        <Label>Protocol</Label>
-        <Dropdown
-          sortby={false}
-          className="!w-full !grow bg-black rounded-md"
-          triggerClassName="!w-full grow justify-between bg-black"
-          contentClassname="!w-full !grow bg-black"
-          selectionList={protocolArray.map((protocol) => ({
-            value: protocol,
-            label: protocol,
-          }))}
-          selected={gauge.metadata?.protocol || protocolArray[0]}
-          onSelect={(value) =>
-            setAction((prev) => ({
-              ...prev,
-              metadata: { ...prev.metadata, protocol: value },
-            }))
-          }
-        />
+        <div className="-mt-1">
+          <Label>Protocol</Label>
+          <Dropdown
+            sortby={false}
+            className="!w-full !grow bg-black rounded-md mt-1"
+            triggerClassName="!w-full grow justify-between bg-black"
+            contentClassname="!w-full !grow bg-black"
+            selectionList={protocolArray.map((protocol) => ({
+              value: protocol,
+              label: protocol,
+            }))}
+            selected={gauge.metadata?.protocol || protocolArray[0]}
+            onSelect={(value) =>
+              setAction((prev) => ({
+                ...prev,
+                metadata: { ...prev.metadata, protocol: value },
+              }))
+            }
+          />
+        </div>
         <InputWithLabel
           variant="black"
           label="URL"
           value={gauge.metadata?.url}
           error={
-            errors?.metadata?.url === ProposalErrorCodes.MUST_BE_URL
-              ? "Must be a valid HTTPS or HTTP url"
+            errors?.metadata?.url === ProposalErrorCodes.MUST_BE_HTTPS
+              ? "Must be a valid HTTPS url"
               : errors?.metadata?.url
           }
           onChange={async (e) => {

--- a/apps/hub/src/app/governance/[genre]/create/components/UpdateVaultWhitelistStatus.tsx
+++ b/apps/hub/src/app/governance/[genre]/create/components/UpdateVaultWhitelistStatus.tsx
@@ -97,7 +97,7 @@ export const UpdateVaultWhitelistStatus = ({
           variant="black"
           label="Name"
           value={gauge.metadata?.name}
-          error={null}
+          error={errors?.metadata?.name ?? null}
           maxLength={40}
           onChange={async (e) => {
             setAction((prev) => ({
@@ -159,7 +159,7 @@ export const UpdateVaultWhitelistStatus = ({
         <TextArea
           id="proposal-message"
           label="Description"
-          error={null}
+          error={errors?.metadata?.description ?? null}
           variant="black"
           placeholder="Tell us about this vault"
           value={gauge.metadata?.description}

--- a/apps/hub/src/app/governance/[genre]/create/components/UpdateVaultWhitelistStatus.tsx
+++ b/apps/hub/src/app/governance/[genre]/create/components/UpdateVaultWhitelistStatus.tsx
@@ -75,6 +75,7 @@ export const UpdateVaultWhitelistStatus = ({
       </div>
       <div className="grid grid-cols-1 gap-6">
         <InputWithLabel
+          id="vault-address"
           variant="black"
           label="Reward Vault Address"
           value={gauge?.vault}
@@ -155,7 +156,7 @@ export const UpdateVaultWhitelistStatus = ({
           }}
         />
         <TextArea
-          id="proposal-message"
+          id="vault-description"
           label="Description"
           error={errors?.metadata?.description}
           variant="black"

--- a/apps/hub/src/app/governance/[genre]/create/components/UpdateVaultWhitelistStatus.tsx
+++ b/apps/hub/src/app/governance/[genre]/create/components/UpdateVaultWhitelistStatus.tsx
@@ -49,7 +49,10 @@ export const UpdateVaultWhitelistStatus = ({
       >,
     ).map((v) => v.product)) as string[]) || ["Loading..."];
 
-  const protocolArray = ["none", ...new Set(protocolValues).values()];
+  const protocolArray = [
+    { value: undefined, label: "No protocol" },
+    ...new Set(protocolValues).values(),
+  ];
 
   const isWhitelisted = gauge.type === ProposalTypeEnum.WHITELIST_REWARD_VAULT;
   return (
@@ -131,10 +134,14 @@ export const UpdateVaultWhitelistStatus = ({
             className="!w-full !grow bg-black rounded-md mt-1"
             triggerClassName="!w-full grow justify-between bg-black"
             contentClassname="!w-full !grow bg-black"
-            selectionList={protocolArray.map((protocol) => ({
-              value: protocol,
-              label: protocol,
-            }))}
+            selectionList={protocolArray.map((protocol) =>
+              typeof protocol === "string"
+                ? {
+                    value: protocol,
+                    label: protocol,
+                  }
+                : protocol,
+            )}
             placeholder="No protocol"
             selected={gauge.metadata?.protocol || ""}
             onSelect={(value) =>

--- a/apps/hub/src/app/governance/[genre]/create/components/UpdateVaultWhitelistStatus.tsx
+++ b/apps/hub/src/app/governance/[genre]/create/components/UpdateVaultWhitelistStatus.tsx
@@ -1,5 +1,17 @@
-import { Dispatch, SetStateAction, useEffect } from "react";
+import { Dispatch, SetStateAction, useEffect, useState } from "react";
+import { beraChefAddress } from "@bera/config";
 import { cn } from "@bera/ui";
+import { InputWithLabel } from "@bera/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@bera/ui/select";
+import { TextArea } from "@bera/ui/text-area";
+import { set } from "date-fns";
+import matter from "gray-matter";
 import { Address } from "viem";
 
 import {
@@ -8,8 +20,8 @@ import {
   ProposalErrorCodes,
   ProposalTypeEnum,
 } from "~/app/governance/types";
-import { InputWithLabel } from "@bera/ui/input";
-import { beraChefAddress } from "@bera/config";
+
+const products = ["Product 1", "Product 2"];
 
 export const UpdateVaultWhitelistStatus = ({
   action: gauge,
@@ -24,6 +36,41 @@ export const UpdateVaultWhitelistStatus = ({
   setAction: Dispatch<SetStateAction<ProposalAction>>;
   errors: CustomProposalActionErrors;
 }) => {
+  const [metadata, setMetadata] = useState<{
+    name?: string;
+    logoURI?: string;
+    product?: string;
+    url?: string;
+    description?: string;
+  }>();
+
+  const nameLengthError =
+    metadata?.name && metadata?.name?.length > 40
+      ? "Name must be less than 40 characters"
+      : null;
+
+  // The logoURI is either a https or http or ipfs cid. It is checked with a regex
+  const logoURIError =
+    metadata?.logoURI &&
+    !/(http|https|ipfs):\/\/[^ "]+$/.test(metadata?.logoURI)
+      ? "Invalid URI"
+      : null;
+
+  const descriptionToolLongError = metadata?.description
+    ? metadata?.description.length > 1000
+      ? `Description must be less than 1000 characters. Current length: ${metadata?.description.length}`
+      : null
+    : null;
+
+  useEffect(() => {
+    if (!metadata?.description) return;
+    const string = matter.stringify(metadata.description, metadata);
+    setAction((prev) => ({
+      ...prev,
+      metadata: string,
+    }));
+  }, [metadata]);
+
   const isWhitelisted = gauge.type === ProposalTypeEnum.WHITELIST_REWARD_VAULT;
   return (
     <>
@@ -66,6 +113,105 @@ export const UpdateVaultWhitelistStatus = ({
             });
           }}
         />
+        {isWhitelisted && (
+          <>
+            <InputWithLabel
+              variant="black"
+              label="Name"
+              value={metadata?.name}
+              error={nameLengthError}
+              maxLength={40}
+              onChange={async (e) => {
+                setMetadata({
+                  ...metadata,
+                  name: e.target.value,
+                });
+              }}
+            />
+            {metadata?.name}
+            <InputWithLabel
+              variant="black"
+              label="Logo URI"
+              value={metadata?.logoURI}
+              error={logoURIError}
+              onChange={async (e) => {
+                setMetadata({
+                  ...metadata,
+                  logoURI: e.target.value,
+                });
+              }}
+            />
+            <InputWithLabel
+              variant="black"
+              label="Product"
+              value={metadata?.product}
+              error={
+                errors?.vault === ProposalErrorCodes.REQUIRED
+                  ? "A Vault Must Be Chosen"
+                  : errors?.vault === ProposalErrorCodes.INVALID_ADDRESS
+                    ? "Invalid Vault address."
+                    : errors?.vault
+              }
+              onChange={async (e) => {
+                setMetadata({
+                  ...metadata,
+                  product: e.target.value,
+                });
+              }}
+            />
+            <Select
+              onValueChange={(value) =>
+                setMetadata({ ...metadata, product: value })
+              }
+            >
+              <SelectTrigger>
+                <SelectValue>{metadata?.product}</SelectValue>
+              </SelectTrigger>
+              <SelectContent>
+                {products.map((product) => (
+                  <SelectItem value={product}>{product}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <InputWithLabel
+              variant="black"
+              label="URL"
+              value={metadata?.url}
+              error={
+                errors?.vault === ProposalErrorCodes.REQUIRED
+                  ? "A Vault Must Be Chosen"
+                  : errors?.vault === ProposalErrorCodes.INVALID_ADDRESS
+                    ? "Invalid Vault address."
+                    : errors?.vault
+              }
+              onChange={async (e) => {
+                setMetadata({
+                  ...metadata,
+                  url: e.target.value,
+                });
+              }}
+            />
+            <TextArea
+              id="proposal-message"
+              label="Description"
+              // error={
+              //   errors.description === ProposalErrorCodes.REQUIRED
+              //     ? "Description must be filled"
+              //     : errors.description
+              // }
+              variant="black"
+              error={descriptionToolLongError}
+              placeholder="Tell us about this vault"
+              value={metadata?.description}
+              onChange={(e) =>
+                setMetadata((prev: any) => ({
+                  ...prev,
+                  description: e.target.value,
+                }))
+              }
+            />{" "}
+          </>
+        )}
       </div>
     </>
   );

--- a/apps/hub/src/app/governance/[genre]/create/components/UpdateVaultWhitelistStatus.tsx
+++ b/apps/hub/src/app/governance/[genre]/create/components/UpdateVaultWhitelistStatus.tsx
@@ -77,6 +77,7 @@ export const UpdateVaultWhitelistStatus = ({
         <InputWithLabel
           id="vault-address"
           variant="black"
+          placeholder="0x..."
           label="Reward Vault Address"
           value={gauge?.vault}
           error={
@@ -98,6 +99,7 @@ export const UpdateVaultWhitelistStatus = ({
           variant="black"
           id="vault-name"
           label="Name"
+          placeholder="Name of the vault"
           value={gauge.metadata?.name}
           error={errors?.metadata?.name}
           maxLength={40}
@@ -112,6 +114,7 @@ export const UpdateVaultWhitelistStatus = ({
           variant="black"
           id="vault-logo-uri"
           label="Logo URI"
+          placeholder="https:// or ipfs://"
           value={gauge.metadata?.logoURI}
           error={errors?.metadata?.logoURI}
           onChange={async (e) => {
@@ -146,6 +149,7 @@ export const UpdateVaultWhitelistStatus = ({
           variant="black"
           id="vault-url"
           label="URL"
+          placeholder="https://"
           value={gauge.metadata?.url}
           error={errors?.metadata?.url}
           onChange={async (e) => {

--- a/apps/hub/src/app/governance/[genre]/create/components/UpdateVaultWhitelistStatus.tsx
+++ b/apps/hub/src/app/governance/[genre]/create/components/UpdateVaultWhitelistStatus.tsx
@@ -49,7 +49,7 @@ export const UpdateVaultWhitelistStatus = ({
       >,
     ).map((v) => v.product)) as string[]) || ["Loading..."];
 
-  const protocolArray = [...new Set(protocolValues).values()];
+  const protocolArray = ["none", ...new Set(protocolValues).values()];
 
   const isWhitelisted = gauge.type === ProposalTypeEnum.WHITELIST_REWARD_VAULT;
   return (
@@ -95,9 +95,10 @@ export const UpdateVaultWhitelistStatus = ({
         />
         <InputWithLabel
           variant="black"
+          id="vault-name"
           label="Name"
           value={gauge.metadata?.name}
-          error={errors?.metadata?.name ?? null}
+          error={errors?.metadata?.name}
           maxLength={40}
           onChange={async (e) => {
             setAction((prev) => ({
@@ -108,14 +109,10 @@ export const UpdateVaultWhitelistStatus = ({
         />
         <InputWithLabel
           variant="black"
+          id="vault-logo-uri"
           label="Logo URI"
           value={gauge.metadata?.logoURI}
-          error={
-            errors?.metadata?.logoURI ===
-            ProposalErrorCodes.MUST_BE_HTTPS_OR_IPFS
-              ? ProposalErrorCodes.MUST_BE_HTTPS_OR_IPFS
-              : errors?.metadata?.logoURI
-          }
+          error={errors?.metadata?.logoURI}
           onChange={async (e) => {
             setAction((prev) => ({
               ...prev,
@@ -134,7 +131,8 @@ export const UpdateVaultWhitelistStatus = ({
               value: protocol,
               label: protocol,
             }))}
-            selected={gauge.metadata?.protocol || protocolArray[0]}
+            placeholder="No protocol"
+            selected={gauge.metadata?.protocol || ""}
             onSelect={(value) =>
               setAction((prev) => ({
                 ...prev,
@@ -145,13 +143,10 @@ export const UpdateVaultWhitelistStatus = ({
         </div>
         <InputWithLabel
           variant="black"
+          id="vault-url"
           label="URL"
           value={gauge.metadata?.url}
-          error={
-            errors?.metadata?.url === ProposalErrorCodes.MUST_BE_HTTPS
-              ? ProposalErrorCodes.MUST_BE_HTTPS
-              : errors?.metadata?.url
-          }
+          error={errors?.metadata?.url}
           onChange={async (e) => {
             setAction((prev) => ({
               ...prev,
@@ -162,7 +157,7 @@ export const UpdateVaultWhitelistStatus = ({
         <TextArea
           id="proposal-message"
           label="Description"
-          error={errors?.metadata?.description ?? null}
+          error={errors?.metadata?.description}
           variant="black"
           placeholder="Tell us about this vault"
           value={gauge.metadata?.description}

--- a/apps/hub/src/app/governance/[genre]/create/components/create-proposal-action.tsx
+++ b/apps/hub/src/app/governance/[genre]/create/components/create-proposal-action.tsx
@@ -100,6 +100,7 @@ export const CreateProposalAction = ({
       {(action.type === ProposalTypeEnum.WHITELIST_REWARD_VAULT ||
         action.type === ProposalTypeEnum.BLACKLIST_REWARD_VAULT) && (
         <UpdateVaultWhitelistStatus
+          id={idx}
           errors={errors}
           action={action}
           setAction={

--- a/apps/hub/src/app/governance/[genre]/create/components/create-proposal-action.tsx
+++ b/apps/hub/src/app/governance/[genre]/create/components/create-proposal-action.tsx
@@ -102,7 +102,17 @@ export const CreateProposalAction = ({
         <UpdateVaultWhitelistStatus
           errors={errors}
           action={action}
-          setAction={setAction}
+          setAction={
+            setAction as Dispatch<
+              SetStateAction<
+                ProposalAction & {
+                  type:
+                    | ProposalTypeEnum.BLACKLIST_REWARD_VAULT
+                    | ProposalTypeEnum.WHITELIST_REWARD_VAULT;
+                }
+              >
+            >
+          }
         />
       )}
       {action.type === ProposalTypeEnum.ERC20_TRANSFER && (

--- a/apps/hub/src/app/governance/[genre]/proposal/[proposalId]/Actions.tsx
+++ b/apps/hub/src/app/governance/[genre]/proposal/[proposalId]/Actions.tsx
@@ -64,7 +64,8 @@ function AbiInput({
         {filteredValues.map(([key, value]) => (
           <div className="my-4">
             {key}:{" "}
-            {value.includes("http://") || value.includes("https://") ? (
+            {(key === "url" && URL.canParse(value)) ||
+            (key === "logoURI" && URL.canParse(value)) ? (
               <a className="font-bold underline" href={value}>
                 {value}
               </a>

--- a/apps/hub/src/app/governance/[genre]/proposal/[proposalId]/Actions.tsx
+++ b/apps/hub/src/app/governance/[genre]/proposal/[proposalId]/Actions.tsx
@@ -12,6 +12,7 @@ import {
   decodeFunctionData,
   erc20Abi,
 } from "viem";
+import matter from "gray-matter";
 
 function AbiInput({
   input,
@@ -49,6 +50,33 @@ function AbiInput({
     //   ));
     // }
   }
+
+  if (input.name === "metadata") {
+    const parsedMetadata = matter(value);
+    const values = Object.entries(parsedMetadata.data);
+
+    const hiddenKeys = ["content-type", "content-encoding", "version"];
+
+    const filteredValues = values.filter(([key]) => !hiddenKeys.includes(key));
+
+    return (
+      <div>
+        {filteredValues.map(([key, value]) => (
+          <div className="m-4">
+            {key} :{" "}
+            {value.includes("http://") || value.includes("https://") ? (
+              <a className="font-bold underline" href={value}>
+                {value}
+              </a>
+            ) : (
+              value
+            )}
+          </div>
+        ))}
+      </div>
+    );
+  }
+
   return (
     <div className="m-4">
       {input.name}: {value?.toString()}

--- a/apps/hub/src/app/governance/[genre]/proposal/[proposalId]/Actions.tsx
+++ b/apps/hub/src/app/governance/[genre]/proposal/[proposalId]/Actions.tsx
@@ -23,7 +23,7 @@ function AbiInput({
 }) {
   if (typeof value === "object") {
     return (
-      <div className="m-4">
+      <div className="my-4">
         {input.name}:
         <pre>
           {JSON.stringify(
@@ -62,8 +62,8 @@ function AbiInput({
     return (
       <div>
         {filteredValues.map(([key, value]) => (
-          <div className="m-4">
-            {key} :{" "}
+          <div className="my-4">
+            {key}:{" "}
             {value.includes("http://") || value.includes("https://") ? (
               <a className="font-bold underline" href={value}>
                 {value}
@@ -78,7 +78,7 @@ function AbiInput({
   }
 
   return (
-    <div className="m-4">
+    <div className="my-4">
       {input.name}: {value?.toString()}
     </div>
   );

--- a/apps/hub/src/app/governance/[genre]/proposal/[proposalId]/components/execute-button.tsx
+++ b/apps/hub/src/app/governance/[genre]/proposal/[proposalId]/components/execute-button.tsx
@@ -23,7 +23,7 @@ export const ExecuteButton = ({
 
   const { write, ModalPortal } = useTxn({
     message: "Executing proposal",
-    onSubmission: () => {
+    onSuccess: () => {
       setIsOpen(false);
       refresh();
     },

--- a/apps/hub/src/app/governance/types.ts
+++ b/apps/hub/src/app/governance/types.ts
@@ -100,18 +100,9 @@ export type SafeProposalAction = {
       calldata: string[];
     }
   | {
-      type: ProposalTypeEnum.WHITELIST_REWARD_VAULT;
-      vault: Address;
-      metadata: Partial<{
-        name: string;
-        logoURI: string;
-        protocol: string;
-        url: string;
-        description: string;
-      }>;
-    }
-  | {
-      type: ProposalTypeEnum.BLACKLIST_REWARD_VAULT;
+      type:
+        | ProposalTypeEnum.WHITELIST_REWARD_VAULT
+        | ProposalTypeEnum.BLACKLIST_REWARD_VAULT;
       vault: Address;
       metadata: Partial<{
         name: string;

--- a/apps/hub/src/app/governance/types.ts
+++ b/apps/hub/src/app/governance/types.ts
@@ -41,6 +41,13 @@ export type CustomProposalActionErrors = {
   isFriend?: null | ProposalErrorCodes;
   to?: null | ProposalErrorCodes;
   amount?: null | ProposalErrorCodes;
+  metadata?: {
+    name?: null | ProposalErrorCodes;
+    logoURI?: null | ProposalErrorCodes;
+    protocol?: null | ProposalErrorCodes;
+    url?: null | ProposalErrorCodes;
+    description?: null | ProposalErrorCodes;
+  } | null;
 } | null;
 
 export type CustomProposalErrors = {
@@ -64,11 +71,14 @@ export enum ProposalErrorCodes {
   INVALID_ACTION = "Invalid action",
   INVALID_ABI = "Invalid ABI",
   MUST_BE_HTTPS = "Must be https",
+  MUST_BE_URL = "Must be a URL",
+  MUST_BE_URL_OR_IPFS = "Must be a URL or IPFS",
   INVALID_BASEPATH = "Must be a berachain forum link",
   /**
    * Mainly used when it's not a reward vault
    */
   INVALID_CONTRACT = "This is not a valid contract",
+  MISSING_METADATA = "Missing metadata",
 }
 
 export type CustomProposal = {
@@ -92,12 +102,24 @@ export type SafeProposalAction = {
   | {
       type: ProposalTypeEnum.WHITELIST_REWARD_VAULT;
       vault: Address;
-      metadata?: string | undefined;
+      metadata: Partial<{
+        name: string;
+        logoURI: string;
+        protocol: string;
+        url: string;
+        description: string;
+      }>;
     }
   | {
       type: ProposalTypeEnum.BLACKLIST_REWARD_VAULT;
       vault: Address;
-      metadata?: string | undefined;
+      metadata: Partial<{
+        name: string;
+        logoURI: string;
+        protocol: string;
+        url: string;
+        description: string;
+      }>;
     }
   | {
       type: ProposalTypeEnum.ERC20_TRANSFER;

--- a/apps/hub/src/app/governance/types.ts
+++ b/apps/hub/src/app/governance/types.ts
@@ -78,7 +78,6 @@ export enum ProposalErrorCodes {
    * Mainly used when it's not a reward vault
    */
   INVALID_CONTRACT = "This is not a valid contract",
-  MISSING_METADATA = "Missing metadata",
 }
 
 export type CustomProposal = {

--- a/apps/hub/src/app/governance/types.ts
+++ b/apps/hub/src/app/governance/types.ts
@@ -70,9 +70,8 @@ export enum ProposalErrorCodes {
   INVALID_ADDRESS = "Invalid address",
   INVALID_ACTION = "Invalid action",
   INVALID_ABI = "Invalid ABI",
-  MUST_BE_HTTPS = "Must be https",
-  MUST_BE_URL = "Must be a URL",
-  MUST_BE_URL_OR_IPFS = "Must be a URL or IPFS",
+  MUST_BE_HTTPS = "Must be HTTPS",
+  MUST_BE_HTTPS_OR_IPFS = "Must HTTPS or IPFS",
   INVALID_BASEPATH = "Must be a berachain forum link",
   /**
    * Mainly used when it's not a reward vault

--- a/apps/hub/src/app/governance/types.ts
+++ b/apps/hub/src/app/governance/types.ts
@@ -71,7 +71,7 @@ export enum ProposalErrorCodes {
   INVALID_ACTION = "Invalid action",
   INVALID_ABI = "Invalid ABI",
   MUST_BE_HTTPS = "Must be HTTPS",
-  MUST_BE_HTTPS_OR_IPFS = "Must HTTPS or IPFS",
+  MUST_BE_HTTPS_OR_IPFS = "Must be HTTPS or IPFS",
   INVALID_BASEPATH = "Must be a berachain forum link",
   /**
    * Mainly used when it's not a reward vault

--- a/apps/hub/src/hooks/useCreateProposal.ts
+++ b/apps/hub/src/hooks/useCreateProposal.ts
@@ -61,7 +61,11 @@ interface CheckProposalField {
       | "action"
       | "title"
       | "forumLink"
-      | "description";
+      | "description"
+      | "name"
+      | "logoURI"
+      | "url"
+      | "protocol";
     value: any;
     required?: boolean;
     baseUrl?: string;
@@ -219,6 +223,36 @@ export const checkProposalField: CheckProposalField = ({
       console.warn("tuple[] default", value, components);
       return null;
 
+    case "name":
+      if (value.length === 0) {
+        return ProposalErrorCodes.REQUIRED;
+      }
+      return null;
+    case "logoURI":
+      if (value.length === 0) {
+        return ProposalErrorCodes.REQUIRED;
+      }
+      if (
+        !value.startsWith("https://") ||
+        !value.startsWith("http://") ||
+        !value.startsWith("ipfs://")
+      ) {
+        return ProposalErrorCodes.MUST_BE_URL_OR_IPFS;
+      }
+      return null;
+    case "protocol":
+      if (value.length === 0) {
+        return ProposalErrorCodes.REQUIRED;
+      }
+      return null;
+    case "url":
+      if (value.length === 0) {
+        return ProposalErrorCodes.REQUIRED;
+      }
+      if (!value.startsWith("https://") || !value.startsWith("http://")) {
+        return ProposalErrorCodes.MUST_BE_URL;
+      }
+      return null;
     default:
       console.error(`Invalid field or type: ${fieldOrType}`);
 
@@ -365,20 +399,56 @@ export const useCreateProposal = ({
           action.type === ProposalTypeEnum.WHITELIST_REWARD_VAULT ||
           action.type === ProposalTypeEnum.BLACKLIST_REWARD_VAULT
         ) {
+          errors.metadata = {};
+
+          errors.metadata.description = checkProposalField({
+            fieldOrType: "description",
+            value: action.metadata?.description,
+          });
+
+          errors.metadata.name = checkProposalField({
+            fieldOrType: "name",
+            value: action.metadata?.name,
+          });
+
+          errors.metadata.logoURI = checkProposalField({
+            fieldOrType: "logoURI",
+            value: action.metadata?.logoURI,
+          });
+
+          errors.metadata.protocol = checkProposalField({
+            fieldOrType: "protocol",
+            value: action.metadata?.protocol,
+          });
+
+          errors.metadata.url = checkProposalField({
+            fieldOrType: "url",
+            value: action.metadata?.url,
+          });
+
+          const hasMetadataErrors = Object.values(errors.metadata).some(
+            (v) => !!v,
+          );
+
           errors.vault = checkProposalField({
             fieldOrType: "address",
             value: action.vault,
           });
-          errors.isFriend = null; //checkProposalField("bool", action.isFriend);
-          const whiteList =
-            action.type === ProposalTypeEnum.WHITELIST_REWARD_VAULT
-              ? true
-              : false;
-          if (!errors.vault) {
+
+          if (!hasMetadataErrors && !errors.vault) {
+            const actionMetadata = action.metadata?.description
+              ? matter.stringify(action.metadata.description, action.metadata)
+              : null;
+
+            const whiteList =
+              action.type === ProposalTypeEnum.WHITELIST_REWARD_VAULT
+                ? true
+                : false;
+
             actions[idx] = encodeFunctionData({
               abi: BERA_CHEF_ABI,
               functionName: "setVaultWhitelistedStatus",
-              args: [action.vault!, whiteList, action.metadata ?? ""], // TODO: A third param was added for metadata. It is optional but we should include it in our action
+              args: [action.vault!, whiteList, actionMetadata ?? ""],
             });
           }
         } else if (action.type === ProposalTypeEnum.ERC20_TRANSFER) {

--- a/apps/hub/src/hooks/useCreateProposal.ts
+++ b/apps/hub/src/hooks/useCreateProposal.ts
@@ -219,12 +219,18 @@ export const checkProposalField: CheckProposalField = ({
 
       return null;
     case "logoURI": {
+      if (value === undefined || value === "") {
+        return null;
+      }
       if (URL.canParse(value) && new URL(value).protocol === "https:") {
         return null;
       }
       return ProposalErrorCodes.MUST_BE_HTTPS_OR_IPFS;
     }
     case "url": {
+      if (value === undefined || value === "") {
+        return null;
+      }
       if (URL.canParse(value) && new URL(value).protocol === "https:") {
         return null;
       }

--- a/apps/hub/src/hooks/useCreateProposal.ts
+++ b/apps/hub/src/hooks/useCreateProposal.ts
@@ -223,9 +223,12 @@ export const checkProposalField: CheckProposalField = ({
 
     case "name":
     case "logoURI": {
+      if (value === undefined || value === null || value === "") {
+        return null;
+      }
       const lowerCaseValue = value.toLowerCase();
       if (
-        (lowerCaseValue.length > 0 && lowerCaseValue.startsWith("https://")) ||
+        lowerCaseValue.startsWith("https://") ||
         lowerCaseValue.startsWith("http://") ||
         lowerCaseValue.startsWith("ipfs://")
       ) {

--- a/apps/hub/src/hooks/useCreateProposal.ts
+++ b/apps/hub/src/hooks/useCreateProposal.ts
@@ -78,6 +78,22 @@ interface CheckProposalField {
   }): CheckProposalFieldResult;
 }
 
+function hasAnyTruthyValues<T extends Record<string, any>>(obj: T): boolean {
+  return Object.values(obj).some((value) => {
+    if (Array.isArray(value)) {
+      return value.some((item) =>
+        typeof item === "object" && item !== null
+          ? hasAnyTruthyValues(item)
+          : !!item,
+      );
+    }
+    if (typeof value === "object" && value !== null) {
+      return hasAnyTruthyValues(value);
+    }
+    return !!value;
+  });
+}
+
 // @ts-expect-error TODO: this is not typed, will throw if not valid
 export const checkProposalField: CheckProposalField = ({
   fieldOrType,
@@ -423,19 +439,26 @@ export const useCreateProposal = ({
             value: action.vault,
           });
 
-          const encodingParams = {
-            "content-type": "text/plain",
-            "content-encoding": "utf-8",
-            version: "1.0.0",
-          };
+          if (!errors.vault && !hasMetadataErrors) {
+            const encodingParams = {
+              "content-type": "text/plain",
+              "content-encoding": "utf-8",
+              version: "1.0.0",
+            };
 
-          if (!hasMetadataErrors && !errors.vault) {
-            const actionMetadata = action.metadata?.description
-              ? matter.stringify(action.metadata.description, {
-                  ...action.metadata,
-                  ...encodingParams,
-                })
-              : null;
+            let metaDataWithoutBlankProtocol = action.metadata;
+            if (action.metadata?.protocol === "none") {
+              const { protocol, ...rest } = action.metadata;
+              metaDataWithoutBlankProtocol = rest;
+            }
+
+            const actionMetadata = matter.stringify(
+              action.metadata?.description ?? "",
+              {
+                ...metaDataWithoutBlankProtocol,
+                ...encodingParams,
+              },
+            );
 
             const whiteList =
               action.type === ProposalTypeEnum.WHITELIST_REWARD_VAULT
@@ -466,17 +489,12 @@ export const useCreateProposal = ({
           }
         }
 
-        const hasErrors = Object.values(e).some((v) => {
-          if (Array.isArray(v)) {
-            return v.filter((v) => v).length > 0;
-          }
-
-          return !!v;
-        });
+        const hasErrors = hasAnyTruthyValues(errors);
 
         if (!hasErrors) {
           return null;
         }
+
         return errors;
       });
 

--- a/apps/hub/src/hooks/useCreateProposal.ts
+++ b/apps/hub/src/hooks/useCreateProposal.ts
@@ -240,10 +240,10 @@ export const checkProposalField: CheckProposalField = ({
     case "protocol":
       return null;
     case "url": {
-      const lowerCaseValue = value.toLowerCase();
-      if (lowerCaseValue.length === 0) {
+      if (value === undefined || value === null || value === "") {
         return null;
       }
+      const lowerCaseValue = value.toLowerCase();
       if (
         lowerCaseValue.startsWith("https://") ||
         lowerCaseValue.startsWith("http://")

--- a/apps/hub/src/hooks/useCreateProposal.ts
+++ b/apps/hub/src/hooks/useCreateProposal.ts
@@ -62,10 +62,8 @@ interface CheckProposalField {
       | "title"
       | "forumLink"
       | "description"
-      | "name"
       | "logoURI"
-      | "url"
-      | "protocol";
+      | "url";
     value: any;
     required?: boolean;
     baseUrl?: string;
@@ -220,37 +218,17 @@ export const checkProposalField: CheckProposalField = ({
       }
 
       return null;
-
-    case "name":
     case "logoURI": {
-      if (value === undefined || value === null || value === "") {
+      if (URL.canParse(value) && new URL(value).protocol === "https:") {
         return null;
       }
-      const lowerCaseValue = value.toLowerCase();
-      if (
-        lowerCaseValue.startsWith("https://") ||
-        lowerCaseValue.startsWith("http://") ||
-        lowerCaseValue.startsWith("ipfs://")
-      ) {
-        return null;
-      }
-      return ProposalErrorCodes.MUST_BE_URL_OR_IPFS;
+      return ProposalErrorCodes.MUST_BE_HTTPS_OR_IPFS;
     }
-
-    case "protocol":
-      return null;
     case "url": {
-      if (value === undefined || value === null || value === "") {
+      if (URL.canParse(value) && new URL(value).protocol === "https:") {
         return null;
       }
-      const lowerCaseValue = value.toLowerCase();
-      if (
-        lowerCaseValue.startsWith("https://") ||
-        lowerCaseValue.startsWith("http://")
-      ) {
-        return null;
-      }
-      return ProposalErrorCodes.MUST_BE_URL;
+      return ProposalErrorCodes.MUST_BE_HTTPS;
     }
     default:
       console.error(`Invalid field or type: ${fieldOrType}`);

--- a/apps/hub/src/hooks/useCreateProposal.ts
+++ b/apps/hub/src/hooks/useCreateProposal.ts
@@ -439,9 +439,18 @@ export const useCreateProposal = ({
             value: action.vault,
           });
 
+          const encodingParams = {
+            "content-type": "text/plain",
+            "content-encoding": "utf-8",
+            version: "1.0.0",
+          };
+
           if (!hasMetadataErrors && !errors.vault) {
             const actionMetadata = action.metadata?.description
-              ? matter.stringify(action.metadata.description, action.metadata)
+              ? matter.stringify(action.metadata.description, {
+                  ...action.metadata,
+                  ...encodingParams,
+                })
               : null;
 
             const whiteList =

--- a/apps/hub/src/hooks/useCreateProposal.ts
+++ b/apps/hub/src/hooks/useCreateProposal.ts
@@ -200,7 +200,6 @@ export const checkProposalField: CheckProposalField = ({
         return errors;
       }
 
-      console.warn("tuple default", value, components);
       return null;
 
     case "tuple[]":
@@ -220,39 +219,36 @@ export const checkProposalField: CheckProposalField = ({
         return errors;
       }
 
-      console.warn("tuple[] default", value, components);
       return null;
 
     case "name":
-      if (value.length === 0) {
-        return ProposalErrorCodes.REQUIRED;
+    case "logoURI": {
+      const lowerCaseValue = value.toLowerCase();
+      if (
+        (lowerCaseValue.length > 0 && lowerCaseValue.startsWith("https://")) ||
+        lowerCaseValue.startsWith("http://") ||
+        lowerCaseValue.startsWith("ipfs://")
+      ) {
+        return null;
       }
+      return ProposalErrorCodes.MUST_BE_URL_OR_IPFS;
+    }
+
+    case "protocol":
       return null;
-    case "logoURI":
-      if (value.length === 0) {
-        return ProposalErrorCodes.REQUIRED;
+    case "url": {
+      const lowerCaseValue = value.toLowerCase();
+      if (lowerCaseValue.length === 0) {
+        return null;
       }
       if (
-        !value.startsWith("https://") ||
-        !value.startsWith("http://") ||
-        !value.startsWith("ipfs://")
+        lowerCaseValue.startsWith("https://") ||
+        lowerCaseValue.startsWith("http://")
       ) {
-        return ProposalErrorCodes.MUST_BE_URL_OR_IPFS;
+        return null;
       }
-      return null;
-    case "protocol":
-      if (value.length === 0) {
-        return ProposalErrorCodes.REQUIRED;
-      }
-      return null;
-    case "url":
-      if (value.length === 0) {
-        return ProposalErrorCodes.REQUIRED;
-      }
-      if (!value.startsWith("https://") || !value.startsWith("http://")) {
-        return ProposalErrorCodes.MUST_BE_URL;
-      }
-      return null;
+      return ProposalErrorCodes.MUST_BE_URL;
+    }
     default:
       console.error(`Invalid field or type: ${fieldOrType}`);
 
@@ -402,28 +398,33 @@ export const useCreateProposal = ({
           errors.metadata = {};
 
           errors.metadata.description = checkProposalField({
-            fieldOrType: "description",
+            fieldOrType: "string",
             value: action.metadata?.description,
+            required: false,
           });
 
           errors.metadata.name = checkProposalField({
-            fieldOrType: "name",
+            fieldOrType: "string",
             value: action.metadata?.name,
+            required: false,
           });
 
           errors.metadata.logoURI = checkProposalField({
             fieldOrType: "logoURI",
             value: action.metadata?.logoURI,
+            required: false,
           });
 
           errors.metadata.protocol = checkProposalField({
-            fieldOrType: "protocol",
+            fieldOrType: "string",
             value: action.metadata?.protocol,
+            required: false,
           });
 
           errors.metadata.url = checkProposalField({
             fieldOrType: "url",
             value: action.metadata?.url,
+            required: false,
           });
 
           const hasMetadataErrors = Object.values(errors.metadata).some(

--- a/apps/lend/src/components/line-chart.tsx
+++ b/apps/lend/src/components/line-chart.tsx
@@ -164,7 +164,7 @@ export default function LineChart({
                 .replaceAll("_", " ")
                 .toUpperCase(),
             )}
-            onSelect={(t: string) => setTime(t as TimeFrameT)}
+            onSelect={(t) => setTime(t as TimeFrameT)}
           />
         </div>
       </div>

--- a/apps/perp/src/app/portfolio/components/stats.tsx
+++ b/apps/perp/src/app/portfolio/components/stats.tsx
@@ -107,7 +107,7 @@ export default function Stats({ markets }: { markets: IMarket[] }) {
             </Tabs>
             <Dropdown
               selected={timeFrame}
-              onSelect={(value: string) => setTimeFrame(value as TimeFrame)}
+              onSelect={(value) => setTimeFrame(value)}
               selectionList={[WEEKLY, MONTHLY, QUARTERLY]}
               sortby={false}
               triggerClassName="bg-muted border border-border"

--- a/packages/shared-ui/src/dropdown.tsx
+++ b/packages/shared-ui/src/dropdown.tsx
@@ -8,7 +8,7 @@ import {
 } from "@bera/ui/dropdown-menu";
 import { Icons } from "@bera/ui/icons";
 
-export const Dropdown = ({
+export const Dropdown = <T extends undefined | string>({
   disabled,
   selected,
   selectionList,
@@ -24,20 +24,20 @@ export const Dropdown = ({
   disabled?: boolean;
   placeholder?: string;
   selectionList: (
-    | string
+    | T
     | {
-        value: string;
+        value: T;
         label: string;
       }
   )[];
-  onSelect: (selected: string) => void;
+  onSelect: (selected: T) => void;
   sortby?: boolean;
   className?: string;
   triggerClassName?: string;
   contentClassname?: string;
 }) => {
-  const selectedFromList = selectionList.find(
-    (s) => typeof s === "object" && s.value === selected,
+  const selectedFromList = selectionList.find((s) =>
+    typeof s === "object" ? s.value === selected : s === selected,
   );
 
   return (
@@ -77,9 +77,9 @@ export const Dropdown = ({
           </DropdownMenuTrigger>
           <DropdownMenuContent className={cn(contentClassname)} align="start">
             {selectionList.map((s) => {
-              const value = typeof s === "string" ? s : s.value;
+              const value = typeof s === "string" ? s : (s?.value as T);
               const label =
-                typeof s === "string" ? s.replaceAll("-", " ") : s.label;
+                typeof s === "string" ? s.replaceAll("-", " ") : s?.label;
               return (
                 <DropdownMenuCheckboxItem
                   key={value}


### PR DESCRIPTION
When whitelisting or blacklisting reward vaults, a user can now furnish the proposal with:
- name
- url
- protocol
- logoURI
- description

These are currently optional. There is basic validation on the strings. For url and logoURI, there is basic validation if these values are not empty

Metadata in a submitted proposal is now parsed and displayed with clickable links.



![Screenshot 2025-01-02 at 17 35 07](https://github.com/user-attachments/assets/7bc8fde3-abc6-4324-b993-6313c08662bf)
![Screenshot 2025-01-02 at 17 21 33](https://github.com/user-attachments/assets/4121d46b-7c51-47c6-9811-85123de79780)

![Screenshot 2025-01-02 at 17 35 12](https://github.com/user-attachments/assets/7926e936-1ff0-4c62-bfe8-5d896971e096)

![Screenshot 2025-01-03 at 12 20 30](https://github.com/user-attachments/assets/2638b4e3-0df3-407d-9c88-eac3fe52f59f)
