### PR TITLE
Fix issue with intermittent Provided Liquidity 

### DIFF
--- a/apps/hub/src/app/pools/usePools.ts
+++ b/apps/hub/src/app/pools/usePools.ts
@@ -55,6 +55,8 @@ export const usePools = ({ keyword }: { keyword: string }) => {
           userAddress: account,
           chain: balancerApiChainName as GqlChain,
         },
+        fetchPolicy: "no-cache",
+        // NOTE: if we allow caching, we intermittantly get data with 0 acct balance, & Provided Liquidity badge will disappear.
       });
       return pools.data?.poolGetPools ?? [];
     },


### PR DESCRIPTION
I tracked this down to an issue where walletPools in `usePools` SWR was returning data with `userBalance` empty (all values 0)

It seems that this is caused by caching _in the Apollo client itself_, and by disabling that caching for user pools SWR we are able to fix the issue.

To confirm this wasn't a BE thing, I tried matching the same request from regular v2 using curl and wasn't able to replicate the issue at the request level, so it seems it's something to do with FE and Apollo with SWR specifically. 