### PR TITLE
fix(set-env.js): replace fs.globSync with glob.sync

### DIFF
--- a/.scripts/set-env.js
+++ b/.scripts/set-env.js
@@ -1,6 +1,7 @@
 const { program } = require("commander");
 const fs = require("fs");
 const path = require("path");
+const glob = require("glob");
 
 program.argument("<env>");
 
@@ -40,7 +41,7 @@ if (process.env.VERCEL && process.env.SENTRY_PROJECT) {
   );
 }
 
-fs.globSync(path.resolve(process.cwd(), "apps/*/next.config.mjs")).forEach(
+glob.sync(path.resolve(process.cwd(), "apps/*/next.config.mjs")).forEach(
   (file) => {
     const envFile = path.resolve(process.cwd(), path.dirname(file), ".env");
 


### PR DESCRIPTION
### Problem
The `set-env.js` script uses `fs.globSync`, which does not exist in the `fs` module, causing a `TypeError` when executed.

### Solution
1. Replaced `fs.globSync` with `glob.sync` from the `glob` module.
2. Added a note that the `glob` module must be installed as a dependency using: ```bash npm install glob

**Changes Made**
-Updated the script to use glob.sync.
-Included the necessary glob module import.

**Issue Reference**
Resolves #341
Resolves the issue: [fs.globSync is not a function in set-env.js script](https://github.com/berachain/monobera/issues/341)

**Test Results**
The script was tested after the changes, and it worked as expected without throwing any errors. Below is the output from running the script:

Node.js v20.11.1
Copying files development
![image](https://github.com/user-attachments/assets/789397f1-9bb5-4740-b74b-279c2b210340)


